### PR TITLE
feat(immich): deploy via official Helm chart in utils namespace

### DIFF
--- a/apps/base/utils/immich/externalsecret.yaml
+++ b/apps/base/utils/immich/externalsecret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: immich-secret
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: /homelab/immich/DB_PASSWORD

--- a/apps/base/utils/immich/helmrelease.yaml
+++ b/apps/base/utils/immich/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: immich
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: immich
+      version: "0.12.0"
+      sourceRef:
+        kind: HelmRepository
+        name: immich
+        namespace: utils
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Shared base merged into every component (server + machine-learning).
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              tag: v2.6.3
+            env:
+              # Database connection to the self-managed Postgres StatefulSet.
+              DB_HOSTNAME: immich-postgres
+              DB_USERNAME: immich
+              DB_DATABASE_NAME: immich
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-secret
+                    key: DB_PASSWORD
+              # REDIS_HOSTNAME ({release}-valkey) and IMMICH_MACHINE_LEARNING_URL
+              # keep their chart defaults.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+
+    immich:
+      persistence:
+        library:
+          existingClaim: immich-library
+
+    # Bundled Redis-compatible cache (disabled by default in this chart).
+    valkey:
+      enabled: true
+
+    server:
+      enabled: true
+      # Pin to the worker because the library hostPath PV lives on /tank there.
+      defaultPodOptions:
+        nodeSelector:
+          kubernetes.io/hostname: worker-node-1
+      ingress:
+        main:
+          enabled: true
+          className: traefik
+          annotations:
+            traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          hosts:
+            - host: immich.homelab
+              paths:
+                - path: /
+                  service:
+                    identifier: main
+
+    machine-learning:
+      enabled: true
+      persistence:
+        # Persist downloaded ML models so they survive pod restarts.
+        # Re-downloadable model files: replicated for availability but excluded
+        # from the weekly S3 backup (longhorn-no-backup has no recurringJobSelector).
+        cache:
+          enabled: true
+          type: persistentVolumeClaim
+          size: 10Gi
+          accessMode: ReadWriteOnce
+          storageClass: longhorn-no-backup

--- a/apps/base/utils/immich/helmrepo.yaml
+++ b/apps/base/utils/immich/helmrepo.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: immich
+spec:
+  interval: 24h
+  url: https://immich-app.github.io/immich-charts

--- a/apps/base/utils/immich/kustomization.yaml
+++ b/apps/base/utils/immich/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepo.yaml
+  - externalsecret.yaml
+  - library-pvc.yaml
+  - postgres.yaml
+  - helmrelease.yaml

--- a/apps/base/utils/immich/library-pvc.yaml
+++ b/apps/base/utils/immich/library-pvc.yaml
@@ -1,0 +1,43 @@
+---
+# Photo library lives on its own ZFS dataset (tank/photos, recordsize=1M,
+# quota=2T) on the 12TB mirror, NFS-mounted at /tank/photos on worker-node-1.
+# The Immich chart only accepts an existing claim for the library, so we back a
+# manually-provisioned hostPath PV with this PVC.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: immich-library
+spec:
+  capacity:
+    storage: 2Ti
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  claimRef:
+    namespace: utils
+    name: immich-library
+  hostPath:
+    path: ${BASE_PATH}/photos
+    type: DirectoryOrCreate
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - worker-node-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  volumeName: immich-library
+  resources:
+    requests:
+      storage: 2Ti

--- a/apps/base/utils/immich/postgres.yaml
+++ b/apps/base/utils/immich/postgres.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-postgres
+  labels:
+    app: immich-postgres
+spec:
+  clusterIP: None
+  selector:
+    app: immich-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: immich-postgres
+  labels:
+    app: immich-postgres
+spec:
+  serviceName: immich-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: immich-postgres
+  template:
+    metadata:
+      labels:
+        app: immich-postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          # Immich-maintained Postgres image with the VectorChord + pgvecto.rs
+          # extensions pre-loaded. Required by Immich for smart search / face recognition.
+          image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: "immich"
+            - name: POSTGRES_DB
+              value: "immich"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-secret
+                  key: DB_PASSWORD
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: dshm
+              mountPath: /dev/shm
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "2Gi"
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "immich", "-d", "immich"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "immich", "-d", "immich"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn-config
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/production/utils/immich/kustomization.yaml
+++ b/apps/production/utils/immich/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: utils
+
+resources:
+  - ../../../base/utils/immich/


### PR DESCRIPTION
## Summary
Deploys Immich (chart **0.12.0**, app **v2.6.3**) using the official `immich-charts` Helm repository into the **utils** namespace via Flux.

The pre-existing immich files targeted the old chart schema (bundled `postgresql`/`redis` subcharts, removed in chart ≥0.10) and were rewritten for 0.12.0's bjw-s common-library structure.

## What's included
- **HelmRelease** — server pinned to `worker-node-1`, bundled valkey cache, Traefik ingress at `immich.homelab`
- **Postgres** — self-managed StatefulSet using the Immich VectorChord image on `longhorn-config` (mirrors the `tracearr-timescale` pattern)
- **Library** — hostPath PV/PVC backed by the dedicated **`tank/photos`** ZFS dataset (1M recordsize, 2T quota), NFS-mounted at `/tank/photos` on the worker
- **ML model cache** — `longhorn-no-backup` (regenerable, excluded from weekly S3 backups)
- **Credentials** — ExternalSecret pulls `DB_PASSWORD` from AWS Parameter Store (`/homelab/immich/DB_PASSWORD`)

## Storage layout
| Data | Location | Backup |
|------|----------|--------|
| Photos/videos | `tank/photos` (2 TB cap, 1M records) on ZFS mirror | ⚠️ no ZFS snapshots yet |
| Postgres metadata | `longhorn-config` 10Gi, 2× replicas | ✅ weekly → S3 |
| ML model cache | `longhorn-no-backup` 10Gi, 2× replicas | ❌ (regenerable) |

## Pre-merge prerequisites (completed)
- [x] `tank/photos` dataset created, 2 TB quota, NFS export + worker mount, writable as UID 1000
- [x] `/homelab/immich/DB_PASSWORD` created in AWS Parameter Store (SecureString, us-east-1)

## Post-merge / follow-up
- [ ] Point DNS `immich.homelab` → Traefik
- [ ] Set up ZFS snapshots + offsite replication for `tank/photos` (pool currently has none)

## Validation
- `kubectl kustomize apps/production/utils/immich/` builds clean
- `helm template` with these values renders correctly: DB env reaches the server, library claim mounted, valkey enabled, ingress class `traefik`, ML cache on `longhorn-no-backup`