### PR TITLE
fix(immich): set PGDATA subdir so initdb works on Longhorn volume

### DIFF
--- a/apps/base/utils/immich/postgres.yaml
+++ b/apps/base/utils/immich/postgres.yaml
@@ -53,6 +53,10 @@ spec:
                   key: DB_PASSWORD
             - name: POSTGRES_INITDB_ARGS
               value: "--data-checksums"
+            # Use a subdirectory, not the mount root: the Longhorn ext4 volume
+            # has a lost+found dir, which makes initdb refuse the mount point.
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
## Problem
`immich-postgres-0` is in `CrashLoopBackOff`. The Longhorn ext4 PVC mounted at `/var/lib/postgresql/data` has a `lost+found` directory, so Postgres `initdb` refuses:

```
initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
It contains a lost+found directory, perhaps due to it being a mount point.
```

`immich-server` consequently crash-loops too (can't reach the DB).

## Fix
Set `PGDATA=/var/lib/postgresql/data/pgdata` so initdb writes into a clean subdirectory of the mount — the same approach used by `tracearr-timescale`. Non-destructive; the existing empty volume just gets a `pgdata/` subdir on next start.