### PR TITLE
fix(ingress): serve immich and vaultwarden over HTTPS only

### DIFF
--- a/apps/base/utils/immich/helmrelease.yaml
+++ b/apps/base/utils/immich/helmrelease.yaml
@@ -68,13 +68,21 @@ spec:
           enabled: true
           className: traefik
           annotations:
+            cert-manager.io/cluster-issuer: selfsigned-issuer
+            # HTTPS only: bind the router to the websecure (443) entrypoint so
+            # port 80 is not served at all for this sensitive app.
             traefik.ingress.kubernetes.io/router.entrypoints: websecure
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
           hosts:
             - host: immich.homelab
               paths:
                 - path: /
                   service:
                     identifier: main
+          tls:
+            - hosts:
+                - immich.homelab
+              secretName: immich-tls
 
     machine-learning:
       enabled: true

--- a/apps/base/utils/vaultwarden/helmrelease.yaml
+++ b/apps/base/utils/vaultwarden/helmrelease.yaml
@@ -62,6 +62,9 @@ spec:
       tlsSecret: "vaultwarden-tls"
       additionalAnnotations:
         cert-manager.io/cluster-issuer: "selfsigned-issuer"
+        # HTTPS only: bind the router to the websecure (443) entrypoint so
+        # port 80 is not served at all for this sensitive app.
+        traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
 
     service:
       type: ClusterIP


### PR DESCRIPTION
## Summary
Both Immich and Vaultwarden expose sensitive data, so they should only be reachable over TLS. This restricts each Traefik router to the **websecure (443)** entrypoint and ensures a cert-manager-issued certificate. Port 80 is no longer served for either host (HTTP gets no route).

## Changes
- **immich** — add `cert-manager.io/cluster-issuer: selfsigned-issuer` + a TLS block (`immich-tls`), keep the `websecure` entrypoint restriction. Previously the router was websecure-only but used Traefik's default cert, and plain HTTP returned a confusing 404.
- **vaultwarden** — add `traefik.ingress.kubernetes.io/router.entrypoints: websecure` (it already had cert-manager TLS via `vaultwarden-tls`). Previously it answered on both 80 and 443.

## After merge
- `https://immich.homelab` and `https://vault.homelab` → served with cert-manager certs
- `http://…` on either → not served (no port-80 router)

> Note: certs come from `selfsigned-issuer`, so browsers will still show a self-signed warning — that's the existing cluster behavior, not changed here.