### PR TITLE
feat(cert-manager): unified homelab-ca for trusted .homelab certs

### DIFF
--- a/apps/base/utils/immich/helmrelease.yaml
+++ b/apps/base/utils/immich/helmrelease.yaml
@@ -68,9 +68,8 @@ spec:
           enabled: true
           className: traefik
           annotations:
-            cert-manager.io/cluster-issuer: selfsigned-issuer
-            # HTTPS only: bind the router to the websecure (443) entrypoint so
-            # port 80 is not served at all for this sensitive app.
+            cert-manager.io/cluster-issuer: ca-issuer
+            # HTTPS only: bind the router to websecure (443), no port 80.
             traefik.ingress.kubernetes.io/router.entrypoints: websecure
             nginx.ingress.kubernetes.io/proxy-body-size: "0"
           hosts:

--- a/apps/base/utils/vaultwarden/helmrelease.yaml
+++ b/apps/base/utils/vaultwarden/helmrelease.yaml
@@ -61,9 +61,8 @@ spec:
       tls: true
       tlsSecret: "vaultwarden-tls"
       additionalAnnotations:
-        cert-manager.io/cluster-issuer: "selfsigned-issuer"
-        # HTTPS only: bind the router to the websecure (443) entrypoint so
-        # port 80 is not served at all for this sensitive app.
+        cert-manager.io/cluster-issuer: "ca-issuer"
+        # HTTPS only: bind the router to websecure (443), no port 80.
         traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
 
     service:

--- a/apps/base/utils/wikijs/helmrelease.yaml
+++ b/apps/base/utils/wikijs/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
     ingress:
       enabled: true
       annotations:
-        cert-manager.io/cluster-issuer: "selfsigned-issuer"
+        cert-manager.io/cluster-issuer: "ca-issuer"
       className: "traefik"
       hosts:
         - host: wiki.homelab

--- a/controllers/base/cert-manager/ca-issuer.yaml
+++ b/controllers/base/cert-manager/ca-issuer.yaml
@@ -1,0 +1,29 @@
+---
+# Root CA for *.homelab. Import homelab-ca-tls's ca.crt once to trust all hosts.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: homelab-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: homelab-ca
+  secretName: homelab-ca-tls
+  duration: 87600h # 10 years
+  renewBefore: 8760h # 1 year
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# CA issuer signing leaf certs with the homelab-ca root above.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: homelab-ca-tls

--- a/controllers/base/cert-manager/kustomization.yaml
+++ b/controllers/base/cert-manager/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - helmrelease.yaml
 - helmrepo.yaml
 - clusterissuer.yaml
+- ca-issuer.yaml


### PR DESCRIPTION
## Summary
Introduces a single local **root CA** (`homelab-ca`) and a `ca-issuer` ClusterIssuer, then repoints `immich`, `vaultwarden`, and `wikijs` from `selfsigned-issuer` to `ca-issuer`.

Today each app cert is an independent self-signed leaf (no shared root), so trusting them in a browser means importing every cert and re-importing on each renewal. With a unified CA you **import the root once** and every `.homelab` service is trusted — and trust survives leaf renewals (leaves chain to the long-lived CA).

## Changes
- `controllers/base/cert-manager/ca-issuer.yaml` — `homelab-ca` Certificate (signed by `selfsigned-issuer`, 10y, secret `homelab-ca-tls` in `cert-manager` ns) + `ca-issuer` CA ClusterIssuer
- repoint `cert-manager.io/cluster-issuer` → `ca-issuer` for immich / vaultwarden / wikijs

## After merge
1. cert-manager mints `homelab-ca` and reissues each app cert via `ca-issuer`
2. Export the root CA and import it into your browser/OS trust store **once**:
   ```
   kubectl -n cert-manager get secret homelab-ca-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > homelab-ca.crt
   ```
3. `https://immich.homelab`, `https://vault.homelab`, `https://wiki.homelab` → trusted (green padlock), no per-host imports