### PR TITLE
fix(monitoring): scrape node & control-plane metrics over host network

### DIFF
--- a/apps/base/monitoring/kube-prometheus-stack/values.yaml
+++ b/apps/base/monitoring/kube-prometheus-stack/values.yaml
@@ -79,9 +79,8 @@ kubelet:
 kubeControllerManager:
   enabled: true
   endpoints:
-    # ips of servers
-    - 192.168.50.18
-    - 192.168.50.18
+    # control-plane, binds 127.0.0.1:10257 (reached via hostNetwork Prometheus)
+    - 127.0.0.1
 
 coreDns:
   enabled: true
@@ -92,9 +91,8 @@ kubeDns:
 kubeEtcd:
   enabled: true
   endpoints:
-    # ips of servers
-    - 192.168.50.18
-    - 192.168.50.18
+    # control-plane localhost; needs k3s --etcd-expose-metrics=true to come up
+    - 127.0.0.1
   service:
     enabled: true
     port: 2381
@@ -103,16 +101,14 @@ kubeEtcd:
 kubeScheduler:
   enabled: true
   endpoints:
-    # ips of servers
-    - 192.168.50.18
-    - 192.168.50.18
+    # control-plane, binds 127.0.0.1:10259 (reached via hostNetwork Prometheus)
+    - 127.0.0.1
 
 kubeProxy:
   enabled: true
   endpoints:
-    # ips of servers
-    - 192.168.50.18
-    - 192.168.50.18
+    # control-plane, binds 127.0.0.1:10249 (reached via hostNetwork Prometheus)
+    - 127.0.0.1
 
 kubeStateMetrics:
   enabled: true
@@ -195,6 +191,9 @@ prometheus:
     evaluationInterval: 30s
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"
+    # host-net so scrapes are host->host (pod->node-IP broken under Cilium Legacy)
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
 
 thanosRuler:
   enabled: false

--- a/controllers/base/cilium/helmrelease.yaml
+++ b/controllers/base/cilium/helmrelease.yaml
@@ -38,3 +38,18 @@ spec:
           - port-distribution
           - icmp
           - httpV2
+  # relay reaches agents at node-IP:4244; pod->node-IP is broken under Legacy
+  # routing, so run relay host-net (chart has no hubble.relay.hostNetwork value)
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: hubble-relay
+            patch: |
+              - op: add
+                path: /spec/template/spec/hostNetwork
+                value: true
+              - op: add
+                path: /spec/template/spec/dnsPolicy
+                value: ClusterFirstWithHostNet


### PR DESCRIPTION
## Problem

All node-IP scrape targets were **down** (node-exporter, kubelet, etcd, scheduler, controller-manager, kube-proxy). Root cause: under Cilium **Legacy host-routing**, a pod cannot reach a node by its **LAN IP** — the host answers ICMP port-unreachable instead of delivering to the socket. Pods can only reach the node via the internal `cilium_host` IP. (metrics-server only worked because it had already been forced to `hostNetwork`.)

Full investigation in `docs/runbooks/cilium-kpr-rca-2026-05-30.md`.

## What this PR does (no datapath / Cilium changes)

- **Prometheus → `hostNetwork: true`** + `dnsPolicy: ClusterFirstWithHostNet`. Prometheus is pinned to the control plane, so scrapes now originate **host→host** (fixes node-exporter + kubelet) and reach the **localhost-bound** control-plane components.
- **Fix wrong endpoints**: etcd / scheduler / controller-manager / kube-proxy were pointed at `192.168.50.18` (worker) — but they run on the **control plane** and bind `127.0.0.1`. Corrected to `127.0.0.1`.
- node-exporter unchanged (already hostNetwork).

## Verification after merge

- Prometheus → Status → Targets: node-exporter, kubelet, scheduler, controller-manager, kube-proxy should go **up**.

## Known follow-ups (NOT in this PR)

- **Hubble UI** (relay reconnect loop): cannot be fixed with hostNetwork — the chain ends at cilium-agent on the node IP `:4244`, so a pod→node-IP hop is unavoidable. Needs the pod→node-IP datapath fix (KPR), which has broken the cluster 3× — see RCA. Or disable hubble.relay/ui to silence the log noise.
- **etcd metrics**: still down until k3s gets `--etcd-expose-metrics=true` (not listening on :2381).
- **NFS resilience** / **traefik+coredns HA**: prerequisites/hardening discussed in the RCA.