### PR TITLE
Migrate config PVCs from Longhorn to static NFS PVs

### DIFF
--- a/apps/base/longhorn/storageclass-longhorn-config.yaml
+++ b/apps/base/longhorn/storageclass-longhorn-config.yaml
@@ -3,7 +3,10 @@ kind: StorageClass
 metadata:
   name: longhorn-config
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    # No default StorageClass cluster-wide: a PVC that omits storageClassName
+    # gets "" (static binding) instead of auto-provisioning on Longhorn.
+    # Static NFS PVs are the intended path; Longhorn is opt-in by name only.
+    storageclass.kubernetes.io/is-default-class: "false"
 provisioner: driver.longhorn.io
 reclaimPolicy: Retain
 allowVolumeExpansion: true

--- a/apps/base/media/jellyfin/deployment.yaml
+++ b/apps/base/media/jellyfin/deployment.yaml
@@ -108,7 +108,7 @@ spec:
             type: Directory
         - name: config
           persistentVolumeClaim:
-            claimName: jellyfin-config
+            claimName: jellyfin-config-nfs
         - name: cache
           emptyDir: {}
         - name: transcodes

--- a/apps/base/media/jellyfin/pvc.yaml
+++ b/apps/base/media/jellyfin/pvc.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/jellyfin
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/jellyfin
   claimRef:
     namespace: media
     name: jellyfin-config-nfs

--- a/apps/base/media/jellyfin/pvc.yaml
+++ b/apps/base/media/jellyfin/pvc.yaml
@@ -1,10 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jellyfin-config-nfs
+spec:
+  capacity:
+    storage: 15Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/jellyfin
+  claimRef:
+    namespace: media
+    name: jellyfin-config-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: jellyfin-config
+  name: jellyfin-config-nfs
 spec:
-  accessModes: ["ReadWriteOnce"]
-  storageClassName: longhorn-no-backup
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: jellyfin-config-nfs
   resources:
     requests:
       storage: 15Gi

--- a/apps/base/media/jellyseer/deployment.yaml
+++ b/apps/base/media/jellyseer/deployment.yaml
@@ -59,4 +59,4 @@ spec:
             type: Directory
         - name: config
           persistentVolumeClaim:
-            claimName: jellyseer-config
+            claimName: jellyseer-config-nfs

--- a/apps/base/media/jellyseer/pvc.yaml
+++ b/apps/base/media/jellyseer/pvc.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/jellyseer
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/jellyseer
   claimRef:
     namespace: media
     name: jellyseer-config-nfs

--- a/apps/base/media/jellyseer/pvc.yaml
+++ b/apps/base/media/jellyseer/pvc.yaml
@@ -1,10 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jellyseer-config-nfs
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/jellyseer
+  claimRef:
+    namespace: media
+    name: jellyseer-config-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: jellyseer-config
+  name: jellyseer-config-nfs
 spec:
-  accessModes: [ "ReadWriteOnce" ]
-  storageClassName: longhorn-config
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: jellyseer-config-nfs
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/media/prowlarr/deployment.yaml
+++ b/apps/base/media/prowlarr/deployment.yaml
@@ -70,4 +70,4 @@ spec:
 
         - name: config
           persistentVolumeClaim:
-            claimName: prowlarr-config
+            claimName: prowlarr-config-nfs

--- a/apps/base/media/prowlarr/pvc.yaml
+++ b/apps/base/media/prowlarr/pvc.yaml
@@ -1,10 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: prowlarr-config-nfs
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/prowlarr
+  claimRef:
+    namespace: media
+    name: prowlarr-config-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: prowlarr-config
+  name: prowlarr-config-nfs
 spec:
-  accessModes: ["ReadWriteOnce"]
-  storageClassName: longhorn-config
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: prowlarr-config-nfs
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/media/prowlarr/pvc.yaml
+++ b/apps/base/media/prowlarr/pvc.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/prowlarr
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/prowlarr
   claimRef:
     namespace: media
     name: prowlarr-config-nfs

--- a/apps/base/media/radarr/deployment.yaml
+++ b/apps/base/media/radarr/deployment.yaml
@@ -47,4 +47,4 @@ spec:
             type: Directory
         - name: config
           persistentVolumeClaim:
-            claimName: radarr-config
+            claimName: radarr-config-nfs

--- a/apps/base/media/radarr/pvc.yaml
+++ b/apps/base/media/radarr/pvc.yaml
@@ -1,10 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: radarr-config-nfs
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/radarr
+  claimRef:
+    namespace: media
+    name: radarr-config-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: radarr-config
+  name: radarr-config-nfs
 spec:
-  accessModes: ["ReadWriteOnce"]
-  storageClassName: longhorn-config
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: radarr-config-nfs
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/media/radarr/pvc.yaml
+++ b/apps/base/media/radarr/pvc.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/radarr
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/radarr
   claimRef:
     namespace: media
     name: radarr-config-nfs

--- a/apps/base/media/sonarr/deployment.yaml
+++ b/apps/base/media/sonarr/deployment.yaml
@@ -48,4 +48,4 @@ spec:
             type: Directory
         - name: config
           persistentVolumeClaim:
-            claimName: sonarr-config
+            claimName: sonarr-config-nfs

--- a/apps/base/media/sonarr/pvc.yaml
+++ b/apps/base/media/sonarr/pvc.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/sonarr
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/sonarr
   claimRef:
     namespace: media
     name: sonarr-config-nfs

--- a/apps/base/media/sonarr/pvc.yaml
+++ b/apps/base/media/sonarr/pvc.yaml
@@ -1,10 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sonarr-config-nfs
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/sonarr
+  claimRef:
+    namespace: media
+    name: sonarr-config-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: sonarr-config
+  name: sonarr-config-nfs
 spec:
-  accessModes: [ "ReadWriteOnce" ]
-  storageClassName: longhorn-config
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: sonarr-config-nfs
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/utils/n8n/deployment.yaml
+++ b/apps/base/utils/n8n/deployment.yaml
@@ -58,4 +58,4 @@ spec:
       volumes:
       - name: n8n-data
         persistentVolumeClaim:
-          claimName: n8n-data
+          claimName: n8n-data-nfs

--- a/apps/base/utils/n8n/storage.yaml
+++ b/apps/base/utils/n8n/storage.yaml
@@ -1,11 +1,32 @@
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: n8n-data-nfs
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: 192.168.50.10
+    path: /tank/k3s-pvcs/n8n
+  claimRef:
+    namespace: utils
+    name: n8n-data-nfs
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: n8n-data
+  name: n8n-data-nfs
 spec:
-  storageClassName: longhorn-config
-  accessModes:
-    - ReadWriteOnce
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: n8n-data-nfs
   resources:
     requests:
       storage: 1Gi

--- a/apps/base/utils/n8n/storage.yaml
+++ b/apps/base/utils/n8n/storage.yaml
@@ -13,8 +13,8 @@ spec:
     - hard
     - noatime
   nfs:
-    server: 192.168.50.10
-    path: /tank/k3s-pvcs/n8n
+    server: ${NFS_SERVER}
+    path: ${NFS_ROOT}/n8n
   claimRef:
     namespace: utils
     name: n8n-data-nfs

--- a/clusters/production/apps.yaml
+++ b/clusters/production/apps.yaml
@@ -7,6 +7,9 @@ spec:
   interval: 10m0s
   dependsOn:
     - name: controllers
+    # apps substitutes ${BASE_PATH}/${NFS_SERVER}/${NFS_ROOT} from the
+    # infra-managed base-path Secret, so it must reconcile after infra.
+    - name: infra
   path: ./apps/production
   prune: true
   sourceRef:

--- a/infrastructure/production/secrets/base-path.yaml
+++ b/infrastructure/production/secrets/base-path.yaml
@@ -5,3 +5,6 @@ metadata:
 type: Opaque
 stringData:
   BASE_PATH: /tank
+  # NFS target for static config PVs (not secret — plain values).
+  NFS_SERVER: 192.168.50.10
+  NFS_ROOT: /tank/k3s-pvcs


### PR DESCRIPTION
## What

Moves the **config volumes** of 6 apps from Longhorn to **static NFS PersistentVolumes** on the new `tank/k3s-pvcs` ZFS dataset (NFS-exported from Proxmox):

`radarr` · `sonarr` · `prowlarr` · `jellyseer` · `jellyfin` · `n8n`

Each `pvc.yaml`/`storage.yaml` becomes a static `PersistentVolume` (`storageClassName: ""`, `Retain`, `ReadWriteMany`, `nfsvers=4.1`) pre-bound via `claimRef` to a renamed PVC `<app>-*-nfs`; the deployment `claimName` is updated to match.

## Why

Stateless-cattle migration. Config as **plain files on `tank`** lets a rebuilt cluster + Flux recreate the PV→path bindings from git and reattach data — unlike Longhorn (state in the VM/etcd) or a dynamic provisioner (random dirs, bindings only in etcd).

## Also in this PR

- **Parameterized NFS target.** PV `server`/`path` use `${NFS_SERVER}` and `${NFS_ROOT}`, injected by Flux `postBuild` from the plaintext `base-path` Secret (same mechanism as `${BASE_PATH}`). Change the server IP or dataset root in **one place** (`infrastructure/production/secrets/base-path.yaml`).
- **Longhorn is no longer the default StorageClass.** With no default, a PVC that omits `storageClassName` resolves to `""` (static binding) instead of auto-provisioning on Longhorn. Verified nothing currently relies on the default. ⚠️ *Consequence:* a new chart PVC that omits a class will stay **Pending** until given a static PV (intended — Longhorn is now opt-in by name).

## Status — data seeded + verified

| App | Size (ZFS) | Files | Verify |
|-----|-----------|-------|--------|
| radarr | 470M | 1531 | count ✓ |
| sonarr | 176M | 1035 | count ✓ |
| prowlarr | 22M | 799 | count ✓ |
| jellyseer | 3.7M | 38 | count ✓ |
| n8n | 13M | 9 | count ✓ |
| jellyfin | 8.5G | 45131 | count ✓ + `library.db`/`jellyfin.db` md5 identical |

Data is at `/tank/k3s-pvcs/<app>`. Apps still run on Longhorn until cutover.

## ⚠️ Cutover runbook — REQUIRED right before merging

The seed is point-in-time; apps keep writing to Longhorn until cutover, so run a final delta with apps **stopped**. Do **not** just merge.

```bash
# 1. suspend Flux so it doesn't fight the scale-down (it reconciles every 10m)
flux suspend kustomization apps

# 2. stop the 6 apps (consistent source)
kubectl -n media scale deploy radarr sonarr prowlarr jellyseer jellyfin --replicas=0
kubectl -n utils scale deploy n8n --replicas=0

# 3. final delta sync Longhorn -> /tank/k3s-pvcs/<app> (per app, via migrator pod)
#    small apps: cp -a ;  jellyfin: tar-to-file + host extract

# 4. merge this PR

# 5. apply — INFRA FIRST so base-path has NFS_SERVER/NFS_ROOT, THEN apps
flux resume kustomization apps
flux reconcile kustomization infra --with-source     # publishes NFS_* vars
flux reconcile kustomization apps                     # creates PVs/PVCs, repoints
```

Flux then creates the static PVs + new PVCs (bound to seeded data), repoints the deployments, and prunes the old Longhorn PVCs (their PVs stay `Retain`ed).

## No fstab / exports changes needed

Both nodes already have the NFS client (`nfs-common`). NFS PVs are mounted **by the kubelet per-pod** — no `/etc/fstab` entry, no further `/etc/exports` work. RWX means pods can schedule on either node.

## Rollback

`git revert` + reconcile. Old Longhorn PVs are `Retain`ed; recover by recreating the original PVCs bound to them.

## Out of scope (later)

Postgres (immich, timescale, wikijs, authentik) via `pg_dump`; the 2 Redis; vaultwarden + authentik **last**; then remove Longhorn.