### PR TITLE
Retire Longhorn — migrate last caches to NFS

### DIFF
--- a/apps/base/media/tracearr/redis-deployment.yaml
+++ b/apps/base/media/tracearr/redis-deployment.yaml
@@ -54,5 +54,5 @@ spec:
       volumes:
         - name: redis-data
           persistentVolumeClaim:
-            claimName: tracearr-redis-data
+            claimName: tracearr-redis-nfs
       restartPolicy: Always

--- a/apps/base/utils/immich/helmrelease.yaml
+++ b/apps/base/utils/immich/helmrelease.yaml
@@ -91,7 +91,6 @@ spec:
         # from the weekly S3 backup (longhorn-no-backup has no recurringJobSelector).
         cache:
           enabled: true
-          type: persistentVolumeClaim
-          size: 10Gi
-          accessMode: ReadWriteOnce
-          storageClass: longhorn-no-backup
+          # Static NFS PV (tank/k3s-pvcs/immich-machine-learning); models are
+          # re-downloadable, so this is just a regenerable cache on NFS.
+          existingClaim: immich-ml-cache-nfs

--- a/apps/base/utils/immich/kustomization.yaml
+++ b/apps/base/utils/immich/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - helmrepo.yaml
   - externalsecret.yaml
   - library-pvc.yaml
+  - ml-cache-pvc.yaml
   - postgres.yaml
   - helmrelease.yaml

--- a/apps/base/utils/immich/ml-cache-pvc.yaml
+++ b/apps/base/utils/immich/ml-cache-pvc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: tracearr-redis-nfs
+  name: immich-ml-cache-nfs
 spec:
   capacity:
-    storage: 1Gi
+    storage: 10Gi
   accessModes: ["ReadWriteMany"]
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
@@ -14,19 +14,19 @@ spec:
     - noatime
   nfs:
     server: ${NFS_SERVER}
-    path: ${NFS_ROOT}/tracearr-redis
+    path: ${NFS_ROOT}/immich-machine-learning
   claimRef:
-    namespace: media
-    name: tracearr-redis-nfs
+    namespace: utils
+    name: immich-ml-cache-nfs
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: tracearr-redis-nfs
+  name: immich-ml-cache-nfs
 spec:
   accessModes: ["ReadWriteMany"]
   storageClassName: ""
-  volumeName: tracearr-redis-nfs
+  volumeName: immich-ml-cache-nfs
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi

--- a/apps/production/longhorn/kustomization.yaml
+++ b/apps/production/longhorn/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: longhorn-system
 
-resources:
-- ../../base/longhorn/
+# Longhorn retired — all storage moved to static NFS PVs on tank/k3s-pvcs.
+# Base manifests kept for reference / possible re-enable.
+# resources:
+# - ../../base/longhorn/


### PR DESCRIPTION
Final step of the storage migration — removes Longhorn entirely.

**Last 2 caches migrated to static NFS PVs** (both regenerable):
- `tracearr-redis` → `tank/k3s-pvcs/tracearr-redis`
- immich `machine-learning` cache → `tank/k3s-pvcs/immich-machine-learning` (chart `existingClaim`)

**Longhorn commented out** in the production overlay (`# - ../../base/longhorn/`) — base manifests kept for reference. Flux will prune the Longhorn operator on reconcile.

**Already done out-of-band:** all 7 Longhorn PVCs + their PVs deleted; `deleting-confirmation-flag=true` set so the helm uninstall completes cleanly.

⚠️ tracearr-redis + immich-ml are scaled to 0 (Flux suspended); they return on merge+reconcile on NFS.

**After you merge:** I'll resume + reconcile, confirm the 2 caches come up on NFS and Longhorn uninstalls cleanly (then the 500GB `tank/longhorn` zvol passthrough can be reclaimed from the VM separately).