### PR TITLE
Media + photos to NFS PVs (last hostPaths) — stateless + cattle-ready

### DIFF
--- a/apps/base/media/bazarr/deployment.yaml
+++ b/apps/base/media/bazarr/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: bazarr
 spec:
   replicas: 1
+  strategy:
+    type: Recreate   # single SQLite writer over NFS — never run two pods at once
   selector:
     matchLabels:
       app: bazarr
@@ -44,9 +46,8 @@ spec:
           mountPath: /config
       volumes:
       - name: media
-        hostPath:
-          path: ${BASE_PATH}/data
-          type: Directory
+        persistentVolumeClaim:
+          claimName: media-data
       - name: config
         persistentVolumeClaim:
           claimName: bazarr-config-nfs

--- a/apps/base/media/jellyfin/deployment.yaml
+++ b/apps/base/media/jellyfin/deployment.yaml
@@ -77,6 +77,7 @@ spec:
           volumeMounts:
             - name: media
               mountPath: /data/media
+              subPath: media
               readOnly: true
             - name: config
               mountPath: /config
@@ -103,9 +104,8 @@ spec:
 
       volumes:
         - name: media
-          hostPath:
-            path: ${BASE_PATH}/data/media
-            type: Directory
+          persistentVolumeClaim:
+            claimName: media-data
         - name: config
           persistentVolumeClaim:
             claimName: jellyfin-config-nfs

--- a/apps/base/media/jellyseer/deployment.yaml
+++ b/apps/base/media/jellyseer/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: jellyseer
 spec:
   replicas: 1
+  strategy:
+    type: Recreate   # single SQLite writer over NFS — never run two pods at once
   selector:
     matchLabels:
       app: jellyseer
@@ -49,14 +51,14 @@ spec:
           volumeMounts:
             - name: media
               mountPath: /data/media
+              subPath: media
               readOnly: true
             - name: config
               mountPath: /app/config
       volumes:
         - name: media
-          hostPath:
-            path: ${BASE_PATH}/data/media
-            type: Directory
+          persistentVolumeClaim:
+            claimName: media-data
         - name: config
           persistentVolumeClaim:
             claimName: jellyseer-config-nfs

--- a/apps/base/media/prowlarr/deployment.yaml
+++ b/apps/base/media/prowlarr/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: prowlarr
 spec:
   replicas: 1
+  strategy:
+    type: Recreate   # single SQLite writer over NFS — never run two pods at once
   selector:
     matchLabels:
       app: prowlarr
@@ -64,9 +66,8 @@ spec:
 
       volumes:
         - name: media
-          hostPath:
-            path: ${BASE_PATH}/data
-            type: Directory
+          persistentVolumeClaim:
+            claimName: media-data
 
         - name: config
           persistentVolumeClaim:

--- a/apps/base/media/qbittorrent/deployment.yaml
+++ b/apps/base/media/qbittorrent/deployment.yaml
@@ -126,6 +126,7 @@ spec:
           mountPath: /config
         - name: downloads
           mountPath: /data/torrents
+          subPath: torrents
 
         resources:
           limits:
@@ -148,6 +149,5 @@ spec:
 
       # Downloads directory
       - name: downloads
-        hostPath:
-          path: ${BASE_PATH}/data/torrents
-          type: Directory
+        persistentVolumeClaim:
+          claimName: media-data

--- a/apps/base/media/radarr/deployment.yaml
+++ b/apps/base/media/radarr/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: radarr
 spec:
   replicas: 1
+  strategy:
+    type: Recreate   # single SQLite writer over NFS — never run two pods at once
   selector:
     matchLabels:
       app: radarr
@@ -42,9 +44,8 @@ spec:
               mountPath: /config
       volumes:
         - name: media
-          hostPath:
-            path: ${BASE_PATH}/data
-            type: Directory
+          persistentVolumeClaim:
+            claimName: media-data
         - name: config
           persistentVolumeClaim:
             claimName: radarr-config-nfs

--- a/apps/base/media/sabnzbd/deployment.yaml
+++ b/apps/base/media/sabnzbd/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: sabnzbd
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sabnzbd
@@ -38,13 +40,13 @@ spec:
         volumeMounts:
         - name: downloads
           mountPath: /data/usenet
+          subPath: usenet
         - name: config
           mountPath: /config
       volumes:
       - name: downloads
-        hostPath:
-          path: ${BASE_PATH}/data/usenet
-          type: Directory
+        persistentVolumeClaim:
+          claimName: media-data
       - name: config
         persistentVolumeClaim:
           claimName: sabnzbd-config-nfs

--- a/apps/base/media/shared/kustomization.yaml
+++ b/apps/base/media/shared/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: media
-
 resources:
-  - ../../../base/media/sonarr/
+  - media-data.yaml

--- a/apps/base/media/shared/media-data.yaml
+++ b/apps/base/media/shared/media-data.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: media-data-nfs
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes: ["ReadWriteMany"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  nfs:
+    server: ${NFS_SERVER}
+    path: ${BASE_PATH}/data
+  claimRef:
+    namespace: media
+    name: media-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-data
+spec:
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ""
+  volumeName: media-data-nfs
+  resources:
+    requests:
+      storage: 10Ti

--- a/apps/base/media/sonarr/deployment.yaml
+++ b/apps/base/media/sonarr/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: sonarr
 spec:
   replicas: 1
+  strategy:
+    type: Recreate   # single SQLite writer over NFS — never run two pods at once
   selector:
     matchLabels:
       app: sonarr
@@ -43,9 +45,8 @@ spec:
 
       volumes:
         - name: media
-          hostPath:
-            path: ${BASE_PATH}/data
-            type: Directory
+          persistentVolumeClaim:
+            claimName: media-data
         - name: config
           persistentVolumeClaim:
             claimName: sonarr-config-nfs

--- a/apps/base/utils/immich/library-pvc.yaml
+++ b/apps/base/utils/immich/library-pvc.yaml
@@ -1,8 +1,7 @@
 ---
-# Photo library lives on its own ZFS dataset (tank/photos, recordsize=1M,
-# quota=2T) on the 12TB mirror, NFS-mounted at /tank/photos on worker-node-1.
-# The Immich chart only accepts an existing claim for the library, so we back a
-# manually-provisioned hostPath PV with this PVC.
+# Photo library on tank/photos (NFS export). Static NFS PV so immich can run on
+# any node (no hostPath, no node pinning). The Immich chart consumes it via
+# existingClaim. RWX so immich-server + machine-learning can both mount it.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -11,23 +10,19 @@ spec:
   capacity:
     storage: 2Ti
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
   claimRef:
     namespace: utils
     name: immich-library
-  hostPath:
+  nfs:
+    server: ${NFS_SERVER}
     path: ${BASE_PATH}/photos
-    type: DirectoryOrCreate
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values:
-                - worker-node-1
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,7 +30,7 @@ metadata:
   name: immich-library
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: ""
   volumeName: immich-library
   resources:

--- a/apps/production/media/bazarr/kustomization.yaml
+++ b/apps/production/media/bazarr/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/bazarr/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/bazarr/node-affinity-patch.yaml
+++ b/apps/production/media/bazarr/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: bazarr
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/jellyfin/kustomization.yaml
+++ b/apps/production/media/jellyfin/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/jellyfin/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/jellyfin/node-affinity-patch.yaml
+++ b/apps/production/media/jellyfin/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: jellyfin
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/jellyseer/kustomization.yaml
+++ b/apps/production/media/jellyseer/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/jellyseer/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/jellyseer/node-affinity-patch.yaml
+++ b/apps/production/media/jellyseer/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: jellyseer
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/notifiarr/kustomization.yaml
+++ b/apps/production/media/notifiarr/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/notifiarr/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/notifiarr/node-affinity-patch.yaml
+++ b/apps/production/media/notifiarr/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: notifiarr
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/prowlarr/kustomization.yaml
+++ b/apps/production/media/prowlarr/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/prowlarr/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/prowlarr/node-affinity-patch.yaml
+++ b/apps/production/media/prowlarr/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prowlarr
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/qbittorrent/kustomization.yaml
+++ b/apps/production/media/qbittorrent/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/qbittorrent/
-
-patchesStrategicMerge:
-  - node-affinity-patch.yaml

--- a/apps/production/media/qbittorrent/node-affinity-patch.yaml
+++ b/apps/production/media/qbittorrent/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: qbittorrent
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/radarr/kustomization.yaml
+++ b/apps/production/media/radarr/kustomization.yaml
@@ -4,6 +4,3 @@ namespace: media
 
 resources:
   - ../../../base/media/radarr/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/radarr/node-affinity-patch.yaml
+++ b/apps/production/media/radarr/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: radarr
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/sabnzbd/kustomization.yaml
+++ b/apps/production/media/sabnzbd/kustomization.yaml
@@ -4,6 +4,3 @@ kind: Kustomization
 namespace: media
 resources:
   - ../../../base/media/sabnzbd/
-
-patches:
-  - path: node-affinity-patch.yaml

--- a/apps/production/media/sabnzbd/node-affinity-patch.yaml
+++ b/apps/production/media/sabnzbd/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sabnzbd
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1

--- a/apps/production/media/shared/kustomization.yaml
+++ b/apps/production/media/shared/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
-
 resources:
-  - ../../../base/media/sonarr/
+  - ../../../base/media/shared/

--- a/apps/production/media/sonarr/node-affinity-patch.yaml
+++ b/apps/production/media/sonarr/node-affinity-patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sonarr
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: worker-node-1


### PR DESCRIPTION
Removes the **last hostPaths** so no node has OS-level NFS mounts or hostname pins — the cluster is fully stateless and the Terraform/Ansible rebuild needs zero per-node mount logic.

## What changed
- **media**: one shared **RWX NFS PV** `media-data` → `tank/data`, mounted **whole at `/data`** by the importers (radarr/sonarr/bazarr/prowlarr) so downloads + library share one `st_dev` → **hardlinks / atomic moves preserved**. qbittorrent (`subPath: torrents`), sabnzbd (`subPath: usenet`), jellyfin/jellyseer (`subPath: media`) use slices of the **same** claim.
- **immich photo library** → NFS PV (`tank/photos`), RWX, no node pinning.
- **`strategy: Recreate`** on the SQLite apps (radarr/sonarr/prowlarr/bazarr/jellyseer; qbittorrent already) → single writer over NFS, never two pods on one DB.
- **All worker hostname node-affinity pins removed.** jellyfin stays on the GPU node via its `gpu.intel.com/i915` request (rebuild-safe — no hardcoded `worker-node-1`); everything else free to schedule anywhere.

## ⚠️ Cutover at merge
- **media apps**: just roll (Recreate) onto `media-data` (new PV, no conflict). No data move — `/tank/data` is already exported.
- **immich-library**: it's an **existing bound PV** changing hostPath→NFS, and PV specs are immutable → Flux apply would fail. So at merge:
  ```bash
  flux suspend kustomization apps
  kubectl -n utils scale deploy immich-server immich-machine-learning --replicas=0
  kubectl -n utils delete pvc immich-library && kubectl delete pv immich-library   # data stays on tank/photos
  flux resume kustomization apps && flux reconcile kustomization apps              # recreates NFS PV+PVC, immich back up
  ```
- After this, the worker's `/tank/data` + `/tank/photos` fstab mounts are unused (kubelet mounts via PVs) — can be removed from fstab later.

## Verify
radarr/sonarr import (hardlink) still works; jellyfin transcodes (GPU); immich photos load.