### PR TITLE
fix(security): drop gluetun privileged mode and run qbittorrent as UID 1000

### DIFF
--- a/apps/base/media/qbittorrent/deployment.yaml
+++ b/apps/base/media/qbittorrent/deployment.yaml
@@ -17,8 +17,6 @@ spec:
         app: qbittorrent
     spec:
       securityContext:
-        runAsUser: 0
-        runAsNonRoot: false
         fsGroup: 911
 
       containers:
@@ -27,10 +25,10 @@ spec:
         image: qmcgaw/gluetun:v3.41.1
         imagePullPolicy: IfNotPresent
         securityContext:
-          privileged: true
           capabilities:
             add:
             - NET_ADMIN
+          allowPrivilegeEscalation: false
 
         env:
         - name: VPN_SERVICE_PROVIDER
@@ -95,9 +93,9 @@ spec:
 
         env:
         - name: PUID
-          value: "0"
+          value: "1000"
         - name: PGID
-          value: "0"
+          value: "1000"
         - name: TZ
           value: "UTC"
         - name: WEBUI_PORT


### PR DESCRIPTION
## Summary

- **gluetun**: Remove `privileged: true` — only `NET_ADMIN` is needed for OpenVPN/TUN interface management. Add `allowPrivilegeEscalation: false`. `privileged: true` granted every Linux kernel capability with no justification.
- **qbittorrent**: Change `PUID`/`PGID` from `0` to `1000` — was explicitly set to root, causing all config and download files to be owned by root on NFS. UID 1000 matches the existing ownership of `/tank/k3s-pvcs/qbittorrent` and `/tank/data/torrents`.
- **pod securityContext**: Remove `runAsUser: 0` and `runAsNonRoot: false` — these were overriding container-level defaults to force root unnecessarily.

## Notes

- s6-overlay (LinuxServer.io init) runs as root briefly on startup to `chown /config` to PUID:PGID — this is expected and will migrate the root-owned config dir to 1000:1000 automatically on first deploy.
- gluetun still mounts `/dev/net/tun` as a hostPath device, which combined with `NET_ADMIN` is sufficient for OpenVPN.

## Test plan

- [ ] Pod comes up healthy after deploy
- [ ] gluetun establishes VPN connection (check logs: `kubectl logs -n media deploy/qbittorrent -c gluetun`)
- [ ] qBittorrent WebUI accessible
- [ ] Downloads directory writeable (start a torrent)
- [ ] Config dir ownership migrated to 1000:1000 on NFS: `ls -lan /tank/k3s-pvcs/qbittorrent/`