### PR TITLE
fix(security): run vaultwarden and tracearr-redis as non-root

### DIFF
--- a/apps/base/media/tracearr/redis-deployment.yaml
+++ b/apps/base/media/tracearr/redis-deployment.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         app: tracearr-redis
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: redis
           image: redis:8.8.0-alpine

--- a/apps/base/utils/vaultwarden/helmrelease.yaml
+++ b/apps/base/utils/vaultwarden/helmrelease.yaml
@@ -63,6 +63,18 @@ spec:
         # HTTPS only: bind the router to websecure (443), no port 80.
         traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
 
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+
     service:
       type: ClusterIP
 


### PR DESCRIPTION
## Summary

- **vaultwarden**: Added podSecurityContext + securityContext to run as UID/GID 1000. vaultwarden/server is a plain Rust binary with no internal user-dropping — safe to set any UID.
- **tracearr-redis**: Overriding the redis:alpine entrypoint bypasses its built-in user drop. Added runAsUser: 999 / runAsGroup: 1000 matching the image built-in redis user.
- **n8n**: App already runs as 1000. NFS dir was pre-created as root — fixed with chown on Proxmox, no manifest change needed.

## Pre-deploy steps already done on Proxmox

chown -R 1000:1000 /tank/k3s-pvcs/vaultwarden
chown -R 999:1000 /tank/k3s-pvcs/tracearr-redis
chown 1000:1000 /tank/k3s-pvcs/n8n

Running pods are unaffected (root ignores ownership). Flux will restart on merge.

## Not included

immich-machine-learning: HOME=/root hardcoded, cache is regenerable ML models, not sensitive.
authentik-postgresql: Bitnami root-init pattern, working as designed.

## Test plan

- [ ] vaultwarden UI accessible, existing vault items present
- [ ] tracearr-redis pod healthy, tracearr connects
- [ ] ls -lan /tank/k3s-pvcs/vaultwarden /tank/k3s-pvcs/tracearr-redis shows correct ownership