### PR TITLE
feat(security): HTTPS for all .homelab services via wildcard cert

### DIFF
--- a/apps/base/media/bazarr/ingress.yaml
+++ b/apps/base/media/bazarr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: bazarr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/jellyfin/ingress.yaml
+++ b/apps/base/media/jellyfin/ingress.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: media
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/jellyseer/ingress.yaml
+++ b/apps/base/media/jellyseer/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: jellyseer
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/notifiarr/ingress.yaml
+++ b/apps/base/media/notifiarr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: notifiarr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/prowlarr/ingress.yaml
+++ b/apps/base/media/prowlarr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: prowlarr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/qbittorrent/ingress.yaml
+++ b/apps/base/media/qbittorrent/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: qbittorrent
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/radarr/ingress.yaml
+++ b/apps/base/media/radarr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: radarr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/sabnzbd/ingress.yaml
+++ b/apps/base/media/sabnzbd/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: sabnzbd
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/sonarr/ingress.yaml
+++ b/apps/base/media/sonarr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: sonarr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/media/tracearr/ingress.yaml
+++ b/apps/base/media/tracearr/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: tracearr
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/base/utils/n8n/ingress.yaml
+++ b/apps/base/utils/n8n/ingress.yaml
@@ -3,7 +3,8 @@ kind: Ingress
 metadata:
   name: n8n
   annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/controllers/base/cert-manager/homelab-wildcard.yaml
+++ b/controllers/base/cert-manager/homelab-wildcard.yaml
@@ -1,0 +1,21 @@
+---
+# Wildcard cert for *.homelab — stored in kube-system so Traefik's TLSStore
+# can reference it as the default certificate for all internal ingresses.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: homelab-wildcard
+  namespace: kube-system
+spec:
+  secretName: homelab-wildcard-tls
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.homelab"
+    - homelab
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256

--- a/controllers/base/cert-manager/kustomization.yaml
+++ b/controllers/base/cert-manager/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - helmrepo.yaml
 - clusterissuer.yaml
 - ca-issuer.yaml
+- homelab-wildcard.yaml

--- a/infrastructure/production/patches/kustomization.yaml
+++ b/infrastructure/production/patches/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - local-path.yaml
   - traefik-helmchartconfig.yaml
+  - traefik-tlsstore.yaml

--- a/infrastructure/production/patches/traefik-helmchartconfig.yaml
+++ b/infrastructure/production/patches/traefik-helmchartconfig.yaml
@@ -8,3 +8,6 @@ spec:
     additionalArguments:
       - "--entryPoints.web.forwardedHeaders.trustedIPs=10.42.0.0/16"
       - "--entryPoints.websecure.forwardedHeaders.trustedIPs=10.42.0.0/16"
+      - "--entryPoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entryPoints.web.http.redirections.entryPoint.scheme=https"
+      - "--entryPoints.web.http.redirections.entryPoint.permanent=true"

--- a/infrastructure/production/patches/traefik-tlsstore.yaml
+++ b/infrastructure/production/patches/traefik-tlsstore.yaml
@@ -1,0 +1,13 @@
+---
+# Sets homelab-wildcard-tls as Traefik's default TLS certificate.
+# Any websecure ingress without an explicit tls secretName will use this cert,
+# covering all *.homelab services without per-ingress cert-manager annotations.
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: kube-system
+spec:
+  defaultCertificate:
+    secretRef:
+      name: homelab-wildcard-tls


### PR DESCRIPTION
## What

Enables HTTPS on all internal \`.homelab\` services using the existing homelab CA, and adds a global HTTP→HTTPS redirect.

## How it works

1. **Wildcard certificate** — \`*.homelab\` cert issued by \`ca-issuer\`, stored in \`kube-system/homelab-wildcard-tls\`. One cert covers every internal service.
2. **Traefik TLSStore default** — tells Traefik to serve the wildcard cert for any \`websecure\` ingress that doesn't specify its own cert. No per-service cert-manager annotations needed on the ingresses.
3. **Global HTTP redirect** — Traefik \`web\` entrypoint now permanently redirects all HTTP traffic to HTTPS.
4. **11 ingresses updated** — all \`.homelab\` ingresses changed from \`entrypoints: web\` → \`websecure\` + \`router.tls: true\`.

## Services affected

sonarr, radarr, bazarr, prowlarr, sabnzbd, qbittorrent, tracearr, notifiarr, jellyfin (LAN), jellyseer (LAN), n8n (LAN)

## Not touched

- vaultwarden, immich, authentik — already HTTPS with their own certs
- External domain ingresses (jellyfin-public, jellyseer-public, n8n-public) — unchanged

## After merging

1. Flux deploys — cert-manager issues the wildcard cert, Traefik restarts with new config
2. Verify: \`kubectl get certificate -n kube-system homelab-wildcard\` → Ready
3. All \`.homelab\` URLs should redirect HTTP→HTTPS and show a valid cert

## Browser trust

If you haven't already imported the homelab CA into your browser/OS (you may have done this for vaultwarden), you'll need to do it once:
\`\`\`
kubectl get secret -n cert-manager homelab-ca-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > homelab-ca.crt
\`\`\`
Then import \`homelab-ca.crt\` as a trusted CA in your browser or OS keychain.