### PR TITLE
fix(traefik): TLSStore secretName field fix

### DIFF
--- a/infrastructure/production/patches/traefik-tlsstore.yaml
+++ b/infrastructure/production/patches/traefik-tlsstore.yaml
@@ -9,5 +9,4 @@ metadata:
   namespace: kube-system
 spec:
   defaultCertificate:
-    secretRef:
-      name: homelab-wildcard-tls
+    secretName: homelab-wildcard-tls


### PR DESCRIPTION
Traefik v3 CRD schema uses `secretName: <name>` directly under `defaultCertificate`, not the `secretRef.name` pattern.

Fixes the dry-run failure introduced in #221:
```
TLSStore/kube-system/default dry-run failed: .spec.defaultCertificate.secretRef: field not declared in schema
```