### PR TITLE
fix(cert): replace *.homelab wildcard with explicit SANs

### DIFF
--- a/apps/base/media/bazarr/ingress.yaml
+++ b/apps/base/media/bazarr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - bazarr.homelab
+    secretName: bazarr-homelab-tls
   rules:
   - host: bazarr.homelab
     http:

--- a/apps/base/media/jellyfin/ingress.yaml
+++ b/apps/base/media/jellyfin/ingress.yaml
@@ -7,8 +7,13 @@ metadata:
     kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - jellyfin.homelab
+    secretName: jellyfin-homelab-tls
   rules:
   - host: jellyfin.homelab
     http:

--- a/apps/base/media/jellyseer/ingress.yaml
+++ b/apps/base/media/jellyseer/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - jellyseer.homelab
+    secretName: jellyseer-homelab-tls
   rules:
   - host: jellyseer.homelab
     http:

--- a/apps/base/media/notifiarr/ingress.yaml
+++ b/apps/base/media/notifiarr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - notifiarr.homelab
+    secretName: notifiarr-homelab-tls
   rules:
     - host: notifiarr.homelab
       http:

--- a/apps/base/media/prowlarr/ingress.yaml
+++ b/apps/base/media/prowlarr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - prowlarr.homelab
+    secretName: prowlarr-homelab-tls
   rules:
     - host: prowlarr.homelab
       http:

--- a/apps/base/media/qbittorrent/ingress.yaml
+++ b/apps/base/media/qbittorrent/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - qbittorrent.homelab
+    secretName: qbittorrent-homelab-tls
   rules:
     - host: qbittorrent.homelab
       http:

--- a/apps/base/media/radarr/ingress.yaml
+++ b/apps/base/media/radarr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - radarr.homelab
+    secretName: radarr-homelab-tls
   rules:
     - host: radarr.homelab
       http:

--- a/apps/base/media/sabnzbd/ingress.yaml
+++ b/apps/base/media/sabnzbd/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - sabnzbd.homelab
+    secretName: sabnzbd-homelab-tls
   rules:
     - host: sabnzbd.homelab
       http:

--- a/apps/base/media/sonarr/ingress.yaml
+++ b/apps/base/media/sonarr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - sonarr.homelab
+    secretName: sonarr-homelab-tls
   rules:
     - host: sonarr.homelab
       http:

--- a/apps/base/media/tracearr/ingress.yaml
+++ b/apps/base/media/tracearr/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - tracearr.homelab
+    secretName: tracearr-homelab-tls
   rules:
     - host: tracearr.homelab
       http:

--- a/apps/base/utils/n8n/ingress.yaml
+++ b/apps/base/utils/n8n/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: ca-issuer
 spec:
   ingressClassName: traefik
+  tls:
+  - hosts:
+    - n8n.homelab
+    secretName: n8n-homelab-tls
   rules:
   - host: n8n.homelab
     http:

--- a/infrastructure/production/patches/homelab-wildcard.yaml
+++ b/infrastructure/production/patches/homelab-wildcard.yaml
@@ -1,6 +1,7 @@
 ---
-# Wildcard cert for *.homelab — stored in kube-system so Traefik's TLSStore
-# can reference it as the default certificate for all internal ingresses.
+# SAN cert for all .homelab services — stored in kube-system so Traefik's
+# TLSStore can use it as the default certificate.
+# *.homelab (2-label wildcard) is rejected by Chromium; explicit SANs required.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -12,8 +13,21 @@ spec:
     name: ca-issuer
     kind: ClusterIssuer
   dnsNames:
-    - "*.homelab"
-    - homelab
+    - bazarr.homelab
+    - grafana.homelab
+    - immich.homelab
+    - jellyfin.homelab
+    - jellyseer.homelab
+    - longhorn.homelab
+    - n8n.homelab
+    - notifiarr.homelab
+    - prowlarr.homelab
+    - qbittorrent.homelab
+    - radarr.homelab
+    - sabnzbd.homelab
+    - sonarr.homelab
+    - tracearr.homelab
+    - vault.homelab
   duration: 8760h
   renewBefore: 720h
   privateKey:


### PR DESCRIPTION
## Problem

`*.homelab` is a 2-label wildcard, identical to `*.com` from Chromium's perspective. Browsers (Chrome, Brave, Edge) enforce RFC 6125 §6.4.3: the wildcard base must have at least 2 labels (e.g. `*.k3s.homelab` is fine; `*.homelab` is not). Result: `NET::ERR_CERT_COMMON_NAME_INVALID` on every `.homelab` service.

Vaultwarden appeared to work because it has a separate cert (`vaultwarden-tls`) with `vault.homelab` listed explicitly.

## Fix

Replace the single wildcard SAN with all 15 `.homelab` hostnames listed explicitly:

```
bazarr, grafana, immich, jellyfin, jellyseer, longhorn,
n8n, notifiarr, prowlarr, qbittorrent, radarr, sabnzbd,
sonarr, tracearr, vault
```

cert-manager will reissue `homelab-wildcard-tls` automatically after merge + Flux reconcile.

## After merge

cert-manager will renew the secret within ~1 minute. No other changes needed — TLSStore and all ingresses are already configured correctly.