### PR TITLE
fix(cloudflared): force http2 transport, drop CPU limit

### DIFF
--- a/apps/base/utils/cloudflared/deployment.yaml
+++ b/apps/base/utils/cloudflared/deployment.yaml
@@ -28,6 +28,8 @@ spec:
                 secretKeyRef:
                   name: tunnel-token
                   key: token
+            - name: TUNNEL_TRANSPORT_PROTOCOL
+              value: "http2"
           command:
             [
               "cloudflared",
@@ -44,7 +46,7 @@ spec:
               containerPort: 2000
           resources:
             requests: { cpu: "50m", memory: "64Mi" }
-            limits: { cpu: "200m", memory: "128Mi" }
+            limits: { memory: "256Mi" }
 
           startupProbe:
             httpGet: { path: /ready, port: 2000 }


### PR DESCRIPTION
## Problem
Jellyfin episode loads take 10s+ over `watch.`/`tv.saharserver.com` (Cloudflare) while `jellyfin.homelab` (LAN) is instant.

## Diagnosis
- Origin (Jellyfin) responds in **~1ms** (`x-response-time-ms: 1.1046`), but a full request through the tunnel takes **~145ms**.
- cloudflared logs flooded with `Failed to handle QUIC stream error="stream … canceled by remote"` — the **QUIC (UDP) transport to the edge is degraded**.
- Jellyfin fires dozens of sequential API calls (+ playback websocket) per episode start → 145ms × N ≈ the 10s delay. LAN skips the tunnel entirely.
- Storage (NFS), Access/WAF rules, and HTTP→HTTPS were all ruled out — they affect both paths or neither.

## Changes
- Set `TUNNEL_TRANSPORT_PROTOCOL=http2` — moves the tunnel off degraded QUIC onto HTTP/2 (TCP), which tolerates lossy/UDP-restricted networks. ([documented flag](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/cloudflared-parameters/run-parameters/))
- Remove the `200m` CPU limit (kept request) — CFS throttling caps tunnel throughput for sustained streaming; matches cluster-wide no-CPU-limit policy.
- Bump memory limit 128Mi → 256Mi for streaming headroom.

## Verify after rollout
```
kubectl logs -n utils -l pod=cloudflared | grep -iE 'http2|quic|protocol'   # expect http2, no QUIC cancel flood
```
Then re-run the per-request timing against `tv.saharserver.com` — ~145ms should drop toward ~30–40ms.

Note: http2 transport does not support post-quantum key agreement (QUIC-only); irrelevant for media streaming.