### PR TITLE
harden(moneyman): isolate namespace, file-mounted secret, egress policy

### DIFF
--- a/apps/base/utils/moneyman/cronjob.yaml
+++ b/apps/base/utils/moneyman/cronjob.yaml
@@ -11,12 +11,32 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: moneyman
         spec:
           restartPolicy: OnFailure
+          serviceAccountName: moneyman
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: moneyman
-              image: ghcr.io/daniel-hauser/moneyman:v2026.06.02.1
-              imagePullPolicy: Always
+              # Pinned by digest so a re-pushed tag can't swap the image.
+              image: ghcr.io/daniel-hauser/moneyman:v2026.06.02.1@sha256:2bf7841db6580a6ee0e57a52e1defe33a299aaca6113d59a36071abe292de8db
+              imagePullPolicy: IfNotPresent
+
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
 
               resources:
                 requests:
@@ -24,13 +44,29 @@ spec:
                   cpu: "200m"
                 limits:
                   memory: "1Gi"
-                  cpu: "1000m"
 
               env:
                 - name: TZ
                   value: Asia/Jerusalem
-                - name: MONEYMAN_CONFIG
-                  valueFrom:
-                    secretKeyRef:
-                      name: moneyman-secret
-                      key: MONEYMAN_CONFIG
+                - name: HOME
+                  value: /tmp
+                # Read config from a file, keeping the secret out of the env.
+                - name: MONEYMAN_CONFIG_PATH
+                  value: /secrets/config.json
+
+              volumeMounts:
+                - name: config
+                  mountPath: /secrets
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+
+          volumes:
+            - name: config
+              secret:
+                secretName: moneyman-secret
+                items:
+                  - key: MONEYMAN_CONFIG
+                    path: config.json
+            - name: tmp
+              emptyDir: {}

--- a/apps/base/utils/moneyman/kustomization.yaml
+++ b/apps/base/utils/moneyman/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cronjob.yaml
+  - serviceaccount.yaml
   - externalsecret.yaml
+  - networkpolicy.yaml
+  - cronjob.yaml

--- a/apps/base/utils/moneyman/networkpolicy.yaml
+++ b/apps/base/utils/moneyman/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: moneyman
+spec:
+  endpointSelector:
+    matchLabels:
+      app: moneyman
+  # Egress default-deny: only DNS + outbound HTTPS allowed.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/utils/moneyman/serviceaccount.yaml
+++ b/apps/base/utils/moneyman/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: moneyman
+automountServiceAccountToken: false

--- a/apps/production/utils/moneyman/kustomization.yaml
+++ b/apps/production/utils/moneyman/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: utils
+namespace: moneyman
 resources:
   - ../../../base/utils/moneyman

--- a/infrastructure/production/namespaces/kustomization.yaml
+++ b/infrastructure/production/namespaces/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - longhorn-ns.yaml
 - cert-manager-ns.yaml
 - external-dns-ns.yaml
+- moneyman-ns.yaml

--- a/infrastructure/production/namespaces/moneyman-ns.yaml
+++ b/infrastructure/production/namespaces/moneyman-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: moneyman


### PR DESCRIPTION
## Why

The `moneyman` CronJob holds full secrets in `MONEYMAN_CONFIG`. Previously it ran in the shared `utils` namespace with the secret injected as an **env var** and unrestricted egress. This PR reduces the blast radius if the cluster, another app, or the third-party image is ever compromised.

## Changes

- **Namespace isolation** — dedicated `moneyman` namespace + token-less ServiceAccount (`automountServiceAccountToken: false`), so other `utils` workloads can't RBAC-reach the secret.
- **File-mounted secret** — config delivered as a tmpfs file via `MONEYMAN_CONFIG_PATH=/secrets/config.json` instead of an env var, keeping it out of `/proc`, child processes and crash dumps.
- **Egress allowlist** — `CiliumNetworkPolicy` with egress default-deny: only DNS (CoreDNS) + outbound HTTPS (`world:443`). Blocks exfiltration and east-west movement. Can be tightened to `toFQDNs` later.
- **Image pinned by digest** — `…@sha256:2bf7841…` so a re-pushed tag can't swap the image holding the credentials.
- **Pod hardening** — `runAsNonRoot`, `readOnlyRootFilesystem` (writable `/tmp` tmpfs + `HOME=/tmp` for Chromium, which runs `--no-sandbox --disable-dev-shm-usage`), `drop: [ALL]`, seccomp `RuntimeDefault`. Dropped the CPU limit per cluster convention.
- **Cleanup** — removed the dead (gitignored) SOPS `secret.yaml`; ESO + AWS Parameter Store remains the source of truth.

## Notes / risks

- Flux `prune` will move the resources out of `utils` into `moneyman` on reconcile (ESO recreates the Secret in the new namespace).
- The Chromium hardening (non-root + read-only rootfs) is the only piece with breakage risk. Worth watching the first run — trigger manually with:
  `kubectl -n moneyman create job --from=cronjob/moneyman moneyman-test`