### PR TITLE
fix(grafana): serve grafana.homelab over HTTPS

### DIFF
--- a/apps/base/monitoring/kube-prometheus-stack/values.yaml
+++ b/apps/base/monitoring/kube-prometheus-stack/values.yaml
@@ -50,11 +50,17 @@ grafana:
   ingress:
     enabled: true
     annotations:
-      traefik.ingress.kubernetes.io/router.entrypoints: web
+      traefik.ingress.kubernetes.io/router.entrypoints: websecure
+      traefik.ingress.kubernetes.io/router.tls: "true"
+      cert-manager.io/cluster-issuer: ca-issuer
     hosts:
       - grafana.homelab
     path: /
     pathType: Prefix
+    tls:
+      - hosts:
+          - grafana.homelab
+        secretName: grafana-homelab-tls
   serviceMonitor:
     enabled: true
   admin:


### PR DESCRIPTION
## Problem
`https://grafana.homelab/` returns **404**. The grafana ingress had `entrypoints=web` (HTTP/port 80 only) and no TLS. With the global HTTP→HTTPS redirect, requests bounce to `https://`, where traefik's `websecure` listener has no router for grafana → 404. Left behind in the HTTPS-everywhere migration (#221/#226).

## Fix
Switch the grafana ingress to `websecure` + `router.tls` + cert-manager `ca-issuer` with a TLS block, matching the working jellyfin `.homelab` pattern.

## Verify after reconcile
`curl -k https://grafana.homelab/` → 302 to /login (not 404).