### PR TITLE
chore: gitignore docs/runbooks/ (keep runbooks local-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ terraform/terraform.tfstate.backup
 terraform/.terraform
 terraform/.terraform.locl.hcl
 /.superset
+
+# Operational runbooks are kept local-only, off the public repo (see commit e233cc3)
+docs/runbooks/


### PR DESCRIPTION
Adds `docs/runbooks/` to `.gitignore` so operational runbooks can't be accidentally committed, per the local-only policy (e233cc3).

Note: `docs/runbooks/zfs-exporter-proxmox.md` is already tracked — gitignore doesn't untrack it. Left as-is; can be untracked separately with `git rm --cached` if you want full local-only.