### PR TITLE
chore(renovate): detect Flux HelmRelease chart + pinned image updates

### DIFF
--- a/apps/base/authentik/helmrepo.yaml
+++ b/apps/base/authentik/helmrepo.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: goauthentik
+  namespace: authentik
 spec:
   interval: 1h
   url: https://charts.goauthentik.io

--- a/apps/base/longhorn/helmrepo.yaml
+++ b/apps/base/longhorn/helmrepo.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: longhorn-repo
+  namespace: longhorn-system
 spec:
   interval: 1h
   url: https://charts.longhorn.io

--- a/apps/base/monitoring/kube-prometheus-stack/helmrepo.yaml
+++ b/apps/base/monitoring/kube-prometheus-stack/helmrepo.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community
+  namespace: monitoring
 spec:
   interval: 24h
   url: https://prometheus-community.github.io/helm-charts

--- a/apps/base/utils/immich/helmrelease.yaml
+++ b/apps/base/utils/immich/helmrelease.yaml
@@ -28,6 +28,7 @@ spec:
         containers:
           main:
             image:
+              # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server
               tag: v2.7.5
             env:
               # Database connection to the self-managed Postgres StatefulSet.

--- a/apps/base/utils/immich/helmrepo.yaml
+++ b/apps/base/utils/immich/helmrepo.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: immich
+  namespace: utils
 spec:
   interval: 24h
   url: https://immich-app.github.io/immich-charts

--- a/apps/base/utils/vaultwarden/helmrepository.yaml
+++ b/apps/base/utils/vaultwarden/helmrepository.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: vaultwarden
+  namespace: utils
 spec:
   interval: 24h
   url: https://guerzon.github.io/vaultwarden

--- a/controllers/base/cert-manager/helmrepo.yaml
+++ b/controllers/base/cert-manager/helmrepo.yaml
@@ -3,6 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack
+  namespace: cert-manager
 spec:
   interval: 24h
   url: https://charts.jetstack.io

--- a/controllers/base/cilium/helmrepo.yaml
+++ b/controllers/base/cilium/helmrepo.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cilium
+  namespace: kube-system
 spec:
   interval: 24h
   url: https://helm.cilium.io/

--- a/controllers/base/external-secrets/helmrepo.yaml
+++ b/controllers/base/external-secrets/helmrepo.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-secrets
+  namespace: external-secrets
 spec:
   interval: 24h
   url: https://charts.external-secrets.io

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,30 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "kubernetes": {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "kubernetes": {
+    "fileMatch": [
+      "\\.yaml$"
+    ]
+  },
+  "flux": {
+    "fileMatch": [
+      "\\.yaml$"
+    ]
+  },
+  "helm-values": {
+    "fileMatch": [
+      "(^|/)helmrelease\\.yaml$"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
       "fileMatch": [
-        "\\.yaml$"
-      ]
+        "(^|/)helmrelease\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
     }
-  }
+  ]
+}


### PR DESCRIPTION
## Why

Renovate wasn't opening PRs for Helm chart updates (authentik, cert-manager, cilium, kube-prometheus-stack, etc.). The config only enabled the **kubernetes** manager, which tracks container image tags — not Flux `HelmRelease` chart versions. The **flux** manager is enabled by default but only scans `gotk-components.yaml`, so our `helmrelease.yaml` files were never read.

## What changed

**`renovate.json`**
- `flux.fileMatch` → all `.yaml` (so it scans every `helmrelease.yaml` / `helmrepo.yaml`)
- `helm-values.fileMatch` → `helmrelease.yaml` (image tags pinned in `values:`, e.g. vaultwarden's `vaultwarden/server`)
- generic regex **customManager** for `# renovate:`-annotated bare tags

**HelmRepository `metadata.namespace` (8 files)**
Renovate joins `HelmRelease.sourceRef → HelmRepository` on `(name, namespace)` from the **raw files** — it does not render kustomize overlays, so the namespaces we inject via overlays were invisible and the join failed. Every release already sets `sourceRef.namespace`; the repos were missing `metadata.namespace`. Added it to each, matching the value each release references. Kustomize overrides to the same value at deploy → **no in-cluster change**.

**`immich/helmrelease.yaml`**
Pinned `immich-server` image has a bare `tag:` with no `repository`, so `helm-values` can't resolve it. Added a `# renovate: datasource=docker depName=ghcr.io/immich-app/immich-server` annotation for the customManager.

## Notes
- `renovate-config-validator`: **Config validated successfully**.
- Design: namespaces live in the manifests (not `registryAliases`), so **new charts need zero `renovate.json` edits** — a new chart from an existing repo is picked up automatically; only a brand-new HelmRepository needs its one `metadata.namespace` line (which you'd write anyway).
- `longhorn` and `immich` are disabled in the production overlays right now but are wired up so re-enabling them Just Works.