### PR TITLE
fix: tune public blackbox probe timeout

### DIFF
--- a/apps/base/monitoring/blackbox-exporter/helmrelease.yaml
+++ b/apps/base/monitoring/blackbox-exporter/helmrelease.yaml
@@ -37,6 +37,17 @@ spec:
             valid_status_codes: [200, 204, 301, 302, 307, 308, 401, 403]
             follow_redirects: true
             preferred_ip_protocol: ip4
+        # Public Cloudflare Access/Tunnel entrypoints can spend multiple seconds
+        # on external DNS and redirect/login-page handling. Keep the normal 5s
+        # timeout for internal app checks, but allow public probes more headroom
+        # so transient Cloudflare Access slowness does not page as an app outage.
+        homelab_public_http:
+          prober: http
+          timeout: 15s
+          http:
+            valid_status_codes: [200, 204, 301, 302, 307, 308, 401, 403]
+            follow_redirects: true
+            preferred_ip_protocol: ip4
         homelab_tcp:
           prober: tcp
           timeout: 5s

--- a/apps/base/monitoring/blackbox-exporter/probes.yaml
+++ b/apps/base/monitoring/blackbox-exporter/probes.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   jobName: blackbox-public-endpoints
   interval: 1m
-  module: homelab_http
+  module: homelab_public_http
   prober:
     url: blackbox-exporter.monitoring.svc.cluster.local:9115
   targets:


### PR DESCRIPTION
## Summary
- add a dedicated `homelab_public_http` blackbox module for public Cloudflare/Tunnel endpoints
- use a 15s timeout for public endpoint probes while keeping the existing 5s timeout for internal service probes
- switch `homelab-public-endpoints` to the new public module

## Why
The `watch.saharserver.com` alert looked like a transient Cloudflare Access/public-path timeout, not a Jellyfin backend outage. Current blackbox debug shows the public probe can spend multiple seconds in DNS/redirect/login handling, and a local curl sample also hit DNS resolution timeout on the Cloudflare Access redirect hostname. Giving public probes more headroom reduces false critical alerts without weakening internal app health checks.

## Validation
- `kubectl kustomize apps/production/monitoring/blackbox-exporter`
- `KUBECONFIG=/home/k3s/.kube/config kubectl apply --dry-run=server -k apps/production/monitoring/blackbox-exporter`
