### PR TITLE
fix: enable Cilium remote-node masquerade

### DIFF
--- a/apps/base/monitoring/kube-prometheus-stack/values.yaml
+++ b/apps/base/monitoring/kube-prometheus-stack/values.yaml
@@ -193,9 +193,6 @@ prometheus:
     evaluationInterval: 30s
     nodeSelector:
       node-role.kubernetes.io/control-plane: "true"
-    # host-net so scrapes are host->host (pod->node-IP broken under Cilium Legacy)
-    hostNetwork: true
-    dnsPolicy: ClusterFirstWithHostNet
     # zfs_exporter runs as a systemd unit on the Proxmox desktop host (port 9134);
     # Server Hub reads these dataset metrics through its Prometheus adapter.
     additionalScrapeConfigs:

--- a/controllers/base/cilium/helmrelease.yaml
+++ b/controllers/base/cilium/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
       retries: 3
   values:
     kubeProxyReplacement: false
+    enableIPv4Masquerade: true
+    enableRemoteNodeMasquerade: true
+    bpf:
+      masquerade: true
     ipam:
       operator:
         clusterPoolIPv4PodCIDRList: "10.42.0.0/16"
@@ -38,18 +42,3 @@ spec:
           - port-distribution
           - icmp
           - httpV2
-  # relay reaches agents at node-IP:4244; pod->node-IP is broken under Legacy
-  # routing, so run relay host-net (chart has no hubble.relay.hostNetwork value)
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: hubble-relay
-            patch: |
-              - op: add
-                path: /spec/template/spec/hostNetwork
-                value: true
-              - op: add
-                path: /spec/template/spec/dnsPolicy
-                value: ClusterFirstWithHostNet


### PR DESCRIPTION
## Summary
- Enable Cilium BPF masquerading plus remote-node masquerading so normal pods can reach remote Kubernetes node InternalIPs.
- Remove the Hubble relay hostNetwork post-renderer workaround now that pod -> remote node IP works.
- Remove Prometheus hostNetwork workaround so Prometheus scrapes from normal pod networking again.

## Why
Cilium pod-to-remote-node-IP traffic was failing under the previous legacy host/iptables masquerade path. The worker-only and then control-plane rollout proved the source-node fix is:

```yaml
bpf:
  masquerade: true
enableIPv4Masquerade: true
enableRemoteNodeMasquerade: true
```

With both nodes running this config via temporary live `CiliumNodeConfig`s:
- worker pod -> saharlinux `:9100` returned `HTTP/1.1 200 OK`
- worker pod -> saharlinux `:10250` returned `HTTP/1.1 401 Unauthorized`
- saharlinux pod -> worker `:9100` returned `HTTP/1.1 200 OK`
- saharlinux pod -> worker `:10250` returned `HTTP/1.1 401 Unauthorized`

The 401s are expected and prove the request reached the real kubelet instead of failing locally with connection refused.

## Live validation already performed
- Both Cilium agents: `Cilium: Ok`
- Both Cilium agents: `Cluster health: 2/2 reachable`
- Both nodes: `Ready`
- metrics-server moved back to pod networking live and `kubectl top nodes` works
- Hubble relay moved back to pod networking live and logs show it connected to both peers
- Prometheus moved back to pod networking live and reports `51/51` active targets up, including the LAN zfs exporter target
- Final firing alerts only: `Watchdog`, `InfoInhibitor`

## GitOps validation
```bash
kubectl kustomize controllers/production/cilium >/tmp/render-cilium.yaml
kubectl kustomize apps/production/monitoring/kube-prometheus-stack >/tmp/render-kps.yaml
KUBECONFIG=/home/k3s/.kube/config kubectl apply --dry-run=server -k controllers/production/cilium
KUBECONFIG=/home/k3s/.kube/config kubectl apply --dry-run=server -k apps/production/monitoring/kube-prometheus-stack
```

Both server dry-runs completed successfully. Existing objects emitted standard `last-applied-configuration` warnings only.

## Follow-up after merge
- Let Flux reconcile this PR.
- After Cilium HelmRelease confirms the global values are active, delete the temporary live `CiliumNodeConfig` objects and labels used for the staged rollout.
- The K3s packaged metrics-server live drift was fixed directly because it is not managed in this repo.
