### PR TITLE
fix: persist Cilium remote-node masquerade config

### DIFF
--- a/controllers/base/cilium/helmrelease.yaml
+++ b/controllers/base/cilium/helmrelease.yaml
@@ -22,9 +22,10 @@ spec:
   values:
     kubeProxyReplacement: false
     enableIPv4Masquerade: true
-    enableRemoteNodeMasquerade: true
     bpf:
       masquerade: true
+    extraConfig:
+      enable-remote-node-masquerade: "true"
     ipam:
       operator:
         clusterPoolIPv4PodCIDRList: "10.42.0.0/16"


### PR DESCRIPTION
## Summary
- Move `enable-remote-node-masquerade` into Cilium Helm `extraConfig` so it is rendered into the `cilium-config` ConfigMap.
- Keep `bpf.masquerade=true` and `enableIPv4Masquerade=true` from PR #276.

## Why
Cilium 1.19.6 supports the agent option `enable-remote-node-masquerade`, but the Helm chart does not expose it as `enableRemoteNodeMasquerade`. The chart-supported way to add arbitrary agent ConfigMap keys is `extraConfig`.

After PR #276 reconciled, `enable-bpf-masquerade=true` was present in `cilium-config`, but `enable-remote-node-masquerade` was missing. The live agents stayed correct only because the staged rollout `CiliumNodeConfig`s were still present. This PR makes the global GitOps config durable.

## Validation
```bash
kubectl kustomize controllers/production/cilium >/tmp/render-cilium-fixed.yaml
KUBECONFIG=/home/k3s/.kube/config kubectl apply --dry-run=server -k controllers/production/cilium
```

The rendered HelmRelease now contains:

```yaml
extraConfig:
  enable-remote-node-masquerade: "true"
```
