### PR TITLE
fix(cloudflared): lower tunnel log level to info

### DIFF
--- a/apps/base/utils/cloudflared/deployment.yaml
+++ b/apps/base/utils/cloudflared/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               "tunnel",
               "--no-autoupdate",
               "--loglevel",
-              "debug",
+              "info",
               "--metrics",
               "0.0.0.0:2000",
               "run",


### PR DESCRIPTION
## Summary
- lower cloudflared tunnel log level from `debug` to `info`
- stop steady-state logging of full Jellyfin/Cloudflare request headers

## Validation
- `kubectl kustomize apps/production/utils/cloudflared`
- verified rendered Deployment now uses `--loglevel info`

## Notes
- No tunnel topology, replicas, transport protocol, probes, or routes changed.
- This PR intentionally only addresses log verbosity/sensitive header logging.
