### PR TITLE
fix(monitoring): reduce public probe alert noise

### DIFF
--- a/apps/base/monitoring/blackbox-exporter/prometheusrule.yaml
+++ b/apps/base/monitoring/blackbox-exporter/prometheusrule.yaml
@@ -9,7 +9,7 @@ spec:
     - name: blackbox.rules
       rules:
         - alert: BlackboxProbeFailed
-          expr: probe_success == 0
+          expr: probe_success{probe_group!="public"} == 0
           for: 2m
           labels:
             severity: critical
@@ -19,7 +19,7 @@ spec:
             summary: "Endpoint down: {{ $labels.instance }}"
             description: "Blackbox probe to {{ $labels.instance }} in group {{ $labels.probe_group }} has been failing for more than 2 minutes."
         - alert: BlackboxProbeSlow
-          expr: probe_duration_seconds > 5
+          expr: probe_duration_seconds{probe_group!="public"} > 5
           for: 5m
           labels:
             severity: warning
@@ -28,3 +28,31 @@ spec:
           annotations:
             summary: "Endpoint slow: {{ $labels.instance }}"
             description: "Blackbox probe to {{ $labels.instance }} in group {{ $labels.probe_group }} took over 5s for 5 minutes."
+        - alert: BlackboxPublicProbeFailed
+          expr: probe_success{probe_group="public"} == 0
+          for: 15m
+          labels:
+            severity: warning
+            component: synthetic-probe
+          annotations:
+            summary: "Public endpoint intermittently unavailable: {{ $labels.instance }}"
+            description: "Public Cloudflare/Tunnel probe to {{ $labels.instance }} has been failing for more than 15 minutes. This is warning-only to avoid spam from short Cloudflare/Tunnel blips."
+        - alert: BlackboxPublicProbeSustainedFailure
+          expr: probe_success{probe_group="public"} == 0
+          for: 30m
+          labels:
+            severity: critical
+            component: synthetic-probe
+            hermes_triage: "true"
+          annotations:
+            summary: "Public endpoint sustained outage: {{ $labels.instance }}"
+            description: "Public Cloudflare/Tunnel probe to {{ $labels.instance }} has been failing for more than 30 minutes. This is sustained enough for Hermes triage."
+        - alert: BlackboxPublicProbeSlow
+          expr: probe_duration_seconds{probe_group="public"} > 10
+          for: 30m
+          labels:
+            severity: warning
+            component: synthetic-probe
+          annotations:
+            summary: "Public endpoint persistently slow: {{ $labels.instance }}"
+            description: "Public Cloudflare/Tunnel probe to {{ $labels.instance }} took over 10s for more than 30 minutes. Short spikes are intentionally ignored."


### PR DESCRIPTION
## Summary
- keep internal/infra blackbox failures strict and Hermes-triaged after 2m
- split public Cloudflare/Tunnel probe alerts from internal alerts
- require sustained public failures before Hermes triage
- ignore short public latency spikes to avoid Telegram/Hermes spam during transient Cloudflare Tunnel blips

## Alert behavior after this PR
- `BlackboxProbeFailed`: non-public probes only, critical, Hermes triage, 2m
- `BlackboxProbeSlow`: non-public probes only, warning, Hermes triage, 5m
- `BlackboxPublicProbeFailed`: public probes, warning only, 15m, no Hermes triage
- `BlackboxPublicProbeSustainedFailure`: public probes, critical, Hermes triage, 30m
- `BlackboxPublicProbeSlow`: public probes, warning only, 30m over 10s, no Hermes triage

## Validation
- `kubectl kustomize apps/production/monitoring/blackbox-exporter`
- `kubectl apply --dry-run=server -f /tmp/blackbox-render.yaml`
