### PR TITLE
test(cloudflared): use automatic tunnel transport

### DIFF
--- a/apps/base/utils/cloudflared/deployment.yaml
+++ b/apps/base/utils/cloudflared/deployment.yaml
@@ -29,7 +29,7 @@ spec:
                   name: tunnel-token
                   key: token
             - name: TUNNEL_TRANSPORT_PROTOCOL
-              value: "http2"
+              value: "auto"
           command:
             [
               "cloudflared",


### PR DESCRIPTION
## Summary
- change `TUNNEL_TRANSPORT_PROTOCOL` from `http2` to `auto`
- lets cloudflared choose QUIC when viable instead of forcing HTTP/2
- intended as a low-risk test for intermittent Jellyfin freezes on `tv.saharserver.com`

## Validation
- `kubectl kustomize apps/production/utils/cloudflared`
- `kubectl apply --dry-run=server -f /tmp/cloudflared-auto-render.yaml`

## Rollback
Revert this PR or change the env var back to `http2`.
