### PR TITLE
feat(jellyfin): add LAN nodeport service

### DIFF
--- a/apps/base/media/jellyfin/kustomization.yaml
+++ b/apps/base/media/jellyfin/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - ingress.yaml
   - service.yaml
+  - service-lan-nodeport.yaml
   - pvc.yaml

--- a/apps/base/media/jellyfin/service-lan-nodeport.yaml
+++ b/apps/base/media/jellyfin/service-lan-nodeport.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-lan-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: jellyfin
+  ports:
+    - name: http
+      port: 8096
+      targetPort: 8096
+      nodePort: 30096


### PR DESCRIPTION
## Summary
- add a separate `jellyfin-lan-nodeport` Service for direct LAN access by node IP and port
- expose Jellyfin HTTP on fixed NodePort `30096`
- leave the existing `jellyfin` ClusterIP service, `jellyfin.homelab` ingress, and Cloudflare/public ingresses unchanged

## LAN usage
- `http://192.168.50.18:30096`
- `http://192.168.50.19:30096`

## Validation
- `kubectl kustomize apps/production/media/jellyfin`
- `kubectl -n media apply --dry-run=server -f apps/base/media/jellyfin/service-lan-nodeport.yaml`

Note: full rendered server dry-run is not valid for this app because existing manifests contain Flux substitutions like `${NFS_SERVER}` and `${BASE_DOMAIN}` before Flux post-build substitution.
