### PR TITLE
feat: deploy splitwise-ynab-sync CronJob in moneyman namespace

### DIFF
--- a/apps/base/utils/splitwise-ynab-sync/cronjob.yaml
+++ b/apps/base/utils/splitwise-ynab-sync/cronjob.yaml
@@ -1,0 +1,95 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: splitwise-ynab-sync
+spec:
+  schedule: "0 * * * *" # hourly
+  timeZone: Asia/Jerusalem
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: splitwise-ynab-sync
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: splitwise-ynab-sync
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: splitwise-ynab-sync
+              # Self-authored, actively developed: floating tag + always pull,
+              # like server-hub, rather than moneyman's pinned-digest pattern.
+              image: ghcr.io/saharariel/splitwise-ynab-sync:main
+              imagePullPolicy: Always
+
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+
+              env:
+                - name: TZ
+                  value: Asia/Jerusalem
+                - name: HOME
+                  value: /tmp
+                # The CronJob schedule is what drives repetition; the app
+                # should sync once per invocation and exit.
+                - name: RUN_ONCE
+                  value: "true"
+                - name: SYNC_START_DATE
+                  value: "2026-07-14"
+                - name: SHARE_FLAG
+                  value: "blue"
+                - name: SPLITWISE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: splitwise-ynab-sync-secret
+                      key: SPLITWISE_API_KEY
+                - name: YNAB_ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: splitwise-ynab-sync-secret
+                      key: YNAB_ACCESS_TOKEN
+                - name: SPLITWISE_GROUP_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: splitwise-ynab-sync-secret
+                      key: SPLITWISE_GROUP_ID
+                - name: YNAB_BUDGET_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: splitwise-ynab-sync-secret
+                      key: YNAB_BUDGET_ID
+                - name: YNAB_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: splitwise-ynab-sync-secret
+                      key: YNAB_ACCOUNT_ID
+
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/base/utils/splitwise-ynab-sync/externalsecret.yaml
+++ b/apps/base/utils/splitwise-ynab-sync/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: splitwise-ynab-sync-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: splitwise-ynab-sync-secret
+  data:
+    - secretKey: SPLITWISE_API_KEY
+      remoteRef:
+        key: /homelab/splitwise-ynab-sync/SPLITWISE_API_KEY
+    - secretKey: YNAB_ACCESS_TOKEN
+      remoteRef:
+        key: /homelab/splitwise-ynab-sync/YNAB_ACCESS_TOKEN
+    - secretKey: SPLITWISE_GROUP_ID
+      remoteRef:
+        key: /homelab/splitwise-ynab-sync/SPLITWISE_GROUP_ID
+    - secretKey: YNAB_BUDGET_ID
+      remoteRef:
+        key: /homelab/splitwise-ynab-sync/YNAB_BUDGET_ID
+    - secretKey: YNAB_ACCOUNT_ID
+      remoteRef:
+        key: /homelab/splitwise-ynab-sync/YNAB_ACCOUNT_ID

--- a/apps/base/utils/splitwise-ynab-sync/kustomization.yaml
+++ b/apps/base/utils/splitwise-ynab-sync/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - externalsecret.yaml
+  - networkpolicy.yaml
+  - cronjob.yaml

--- a/apps/base/utils/splitwise-ynab-sync/networkpolicy.yaml
+++ b/apps/base/utils/splitwise-ynab-sync/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: splitwise-ynab-sync
+spec:
+  endpointSelector:
+    matchLabels:
+      app: splitwise-ynab-sync
+  # Egress default-deny: only DNS + outbound HTTPS allowed (Splitwise + YNAB APIs).
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/utils/splitwise-ynab-sync/serviceaccount.yaml
+++ b/apps/base/utils/splitwise-ynab-sync/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: splitwise-ynab-sync
+automountServiceAccountToken: false

--- a/apps/production/utils/splitwise-ynab-sync/kustomization.yaml
+++ b/apps/production/utils/splitwise-ynab-sync/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: moneyman
+resources:
+  - ../../../base/utils/splitwise-ynab-sync


### PR DESCRIPTION
## Summary
- Deploys [splitwise-ynab-sync](https://github.com/Saharariel/splitwise-ynab-sync) as an hourly CronJob in the existing `moneyman` namespace
- Follows moneyman's established pattern: `ExternalSecret` pulling from AWS Parameter Store, DNS+HTTPS-only Cilium egress policy, non-root/read-only-filesystem security context
- Unlike moneyman, tracks a floating `:main` tag with `imagePullPolicy: Always` (self-authored, actively-developed code, same convention as `server-hub`) rather than a pinned digest updated via Renovate

## Before merging
- [ ] **Set the GHCR package public**: `github.com/users/Saharariel/packages/container/splitwise-ynab-sync/settings` → Danger Zone → Change visibility → Public. No `imagePullSecrets` are configured, so the CronJob will hit `ImagePullBackOff` until this is done (matches how `moneyman`'s and `server-hub`'s images are public).
- [ ] **Push secrets to AWS Parameter Store** under `/homelab/splitwise-ynab-sync/`: `SPLITWISE_API_KEY`, `YNAB_ACCESS_TOKEN`, `SPLITWISE_GROUP_ID`, `YNAB_BUDGET_ID`, `YNAB_ACCOUNT_ID` (all `SecureString`). The `ExternalSecret` in this PR expects them at those exact paths.

## Test plan
- [x] `kubectl kustomize apps/production/utils/splitwise-ynab-sync` builds cleanly and resolves into the `moneyman` namespace
- [x] CI in the source repo (typecheck + image build/push to GHCR) is green
- [ ] After merge + the two steps above: confirm the CronJob's first scheduled run (or `kubectl create job --from=cronjob/splitwise-ynab-sync -n moneyman manual-test`) completes successfully and pulls the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)