### PR TITLE
feat(utils): add Homarr Helm release

### DIFF
--- a/apps/base/utils/homarr/externalsecret.yaml
+++ b/apps/base/utils/homarr/externalsecret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homarr-db-encryption
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: homarr-db-encryption
+  data:
+    - secretKey: db-encryption-key
+      remoteRef:
+        key: /homelab/homarr/db-encryption-key

--- a/apps/base/utils/homarr/helmrelease.yaml
+++ b/apps/base/utils/homarr/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homarr
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: homarr
+      version: "8.27.0"
+      sourceRef:
+        kind: HelmRepository
+        name: homarr
+        namespace: utils
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    strategyType: Recreate
+
+    env:
+      TZ: Asia/Jerusalem
+
+    envSecrets:
+      dbEncryption:
+        existingSecret: homarr-db-encryption
+        key: db-encryption-key
+
+    persistence:
+      homarrDatabase:
+        enabled: true
+        storageClassName: local-path
+        accessMode: ReadWriteOnce
+        size: 1Gi
+
+    service:
+      enabled: true
+      type: ClusterIP
+
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: ca-issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        traefik.ingress.kubernetes.io/router.tls: "true"
+      hosts:
+        - host: homarr.homelab
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: homarr-homelab-tls
+          hosts:
+            - homarr.homelab
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+    rbac:
+      enabled: false

--- a/apps/base/utils/homarr/helmrepository.yaml
+++ b/apps/base/utils/homarr/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: homarr
+  namespace: utils
+spec:
+  interval: 24h
+  url: https://homarr-labs.github.io/charts/

--- a/apps/base/utils/homarr/kustomization.yaml
+++ b/apps/base/utils/homarr/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml

--- a/apps/production/utils/homarr/kustomization.yaml
+++ b/apps/production/utils/homarr/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: utils
+resources:
+  - ../../../base/utils/homarr/


### PR DESCRIPTION
## Summary

- deploy Homarr in the existing `utils` namespace using the official `homarr-labs` Helm chart
- expose it only on the local Traefik ingress at `https://homarr.homelab`
- persist the SQLite database on a 1 Gi `local-path` RWO PVC with a `Recreate` rollout strategy
- source Homarr's required database encryption key from AWS Parameter Store through External Secrets
- keep Kubernetes integration/RBAC disabled by default
- pin chart `8.27.0` in a Flux `HelmRelease` so Renovate can manage updates

No Cloudflare tunnel route, public hostname, or external DNS record is added. The existing Pi-hole ExternalDNS controller will handle the `.homelab` ingress locally.

## Validation

- [x] Official Homarr installation documentation checked for repository, encryption Secret, persistence, service, ingress, and port requirements
- [x] Official chart `8.27.0` downloaded and checksum-verified
- [x] `helm lint --strict` passes
- [x] `helm template` renders successfully
- [x] Homarr production overlay renders with `kubectl kustomize`
- [x] Full Flux `apps` root renders with strict substitutions
- [x] GitOps CRs pass Kubernetes server-side dry-run
- [x] Rendered chart resources pass server-side dry-run in namespace `utils`
- [x] Assertions verify SQLite/PVC wiring, RWO + Recreate, health probes, encryption Secret reference, ClusterIP service, local-only Traefik TLS ingress, and disabled RBAC
- [x] Renovate local dry-run extracts `homarr` `8.27.0` from the official Helm repository using the Flux manager
- [x] SSM SecureString `/homelab/homarr/db-encryption-key` exists; its value was not read or committed
- [x] No plaintext Kubernetes Secret or public exposure configuration added

## Post-merge validation

This PR has been statically rendered and API-validated, but Homarr is not deployed before merge. After Flux reconciles the merged revision, verify the HelmRelease, ExternalSecret, PVC, Certificate, Deployment, local DNS, and `https://homarr.homelab` response.
