### PR TITLE
feat(utils): configure Homarr DNS and Kubernetes dashboard

### DIFF
--- a/apps/base/utils/homarr/helmrelease.yaml
+++ b/apps/base/utils/homarr/helmrelease.yaml
@@ -21,11 +21,36 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: homarr
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: homarr
+              spec:
+                template:
+                  spec:
+                    serviceAccountName: homarr-kubernetes
+                    dnsPolicy: None
+                    dnsConfig:
+                      nameservers:
+                        - 192.168.50.20
+                      options:
+                        - name: ndots
+                          value: "1"
   values:
     strategyType: Recreate
 
     env:
       TZ: Asia/Jerusalem
+      KUBERNETES_SERVICE_ACCOUNT_NAME: homarr-kubernetes
 
     envSecrets:
       dbEncryption:
@@ -68,5 +93,6 @@ spec:
         cpu: "1"
         memory: 1Gi
 
+    # Custom RBAC in rbac.yaml grants only the API calls Homarr currently makes.
     rbac:
       enabled: false

--- a/apps/base/utils/homarr/kustomization.yaml
+++ b/apps/base/utils/homarr/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - helmrepository.yaml
   - externalsecret.yaml
+  - rbac.yaml
   - helmrelease.yaml

--- a/apps/base/utils/homarr/rbac.yaml
+++ b/apps/base/utils/homarr/rbac.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homarr-kubernetes
+  namespace: utils
+# Homarr reads the projected token and CA from the standard in-cluster paths.
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homarr-kubernetes-readonly
+rules:
+  # Homarr lists these resources across namespaces for its dashboard pages and counts.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - services
+    verbs:
+      - list
+  # Homarr reads ReplicaSet ownership to identify the workload behind a Pod.
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+  # Homarr uses node metrics for cluster CPU and memory gauges.
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homarr-kubernetes-readonly
+subjects:
+  - kind: ServiceAccount
+    name: homarr-kubernetes
+    namespace: utils
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homarr-kubernetes-readonly


### PR DESCRIPTION
## Summary

- route Homarr DNS directly through Pi-hole at `192.168.50.20` so `.homelab` links resolve consistently
- enable Homarr's built-in Kubernetes dashboard with a dedicated projected-token ServiceAccount
- grant a custom, source-audited read-only ClusterRole instead of the chart's broader default RBAC
- keep the chart-managed RBAC disabled to avoid its duplicate Role/RoleBinding and legacy ServiceAccount token Secret

## Kubernetes integration

The permissions were derived from the exact deployed Homarr `v1.75.0` source:

- `list`: pods, services, ConfigMaps, Secrets, PVCs, namespaces, nodes, ingresses, and node metrics
- `get`: ReplicaSets, used to identify Pod workload ownership
- no create, update, patch, delete, watch, or `use` permissions

Homarr's Kubernetes routes are also restricted to Homarr administrators in the application.

### Security note

Homarr's resource-count endpoint and Secrets page call `listSecretForAllNamespaces()`. Kubernetes Secret list responses include Secret data even though Homarr's UI maps only metadata. Therefore this integration gives the Homarr ServiceAccount cluster-wide read exposure to Secret objects. This is required for the complete upstream dashboard behavior and is explicitly enabled by this PR; the role grants only `list`, not `get` or mutation verbs.

## DNS scope

- only the Homarr Deployment receives `dnsPolicy: None`
- Pi-hole `192.168.50.20` is its resolver
- no CoreDNS, public DNS, Cloudflare, or other workload configuration changes
- Kubernetes API access remains available through the injected `KUBERNETES_SERVICE_HOST` service IP and projected ServiceAccount CA/token

## Validation

- `kubectl kustomize apps/production/utils/homarr`
- `flux build kustomization apps --path apps/production --strict-substitute`
- server-side dry-run of the GitOps overlay and custom RBAC
- `helm lint --strict` against Homarr chart `8.27.0`
- rendered the upstream chart and applied the exact Flux post-render patch
- server-side dry-run of the rendered Homarr workload
- asserted ServiceAccount, ClusterRole, binding, exact verbs/resources, Pi-hole resolver, and absence of chart RBAC/token overlap
- confirmed Pi-hole resolves all 16 current `.homelab` ingress names
- confirmed the live Homarr pod reaches Kubernetes API service `10.43.0.1` using the mounted cluster CA
- scanned the complete staged diff for credential material

## Post-merge verification

- verify the replacement Homarr pod uses ServiceAccount `homarr-kubernetes`
- verify all `.homelab` names resolve from the pod
- verify `kubectl auth can-i` allows only the intended reads and denies mutation
- verify the Homarr Kubernetes dashboard loads cluster metrics and resources
