### PR TITLE
fix(homarr): enable Kubernetes integration in UI

### DIFF
--- a/apps/base/utils/homarr/helmrelease.yaml
+++ b/apps/base/utils/homarr/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
     env:
       TZ: Asia/Jerusalem
       KUBERNETES_SERVICE_ACCOUNT_NAME: homarr-kubernetes
+      ENABLE_KUBERNETES: "true"
 
     envSecrets:
       dbEncryption:


### PR DESCRIPTION
## Summary
- Homarr's `rbac.yaml` hand-crafts RBAC (ServiceAccount, ClusterRole, ClusterRoleBinding) instead of using the chart's built-in RBAC, so `rbac.enabled: false` is set in the HelmRelease.
- The `homarr` chart (dev branch, chart v8.27.0) ties the `ENABLE_KUBERNETES` env var directly to `rbac.enabled`, so the Kubernetes tool was silently hidden in the UI even though the service account, RBAC, and `KUBERNETES_SERVICE_ACCOUNT_NAME` were all correctly configured.
- Verified against the live cluster: `ENABLE_KUBERNETES=false` in the running `homarr` deployment's env, confirming this as the root cause.
- Adds `ENABLE_KUBERNETES: "true"` to `values.env`, which the chart appends after its own conditional block, overriding it back to enabled.

## Test plan
- [x] Rendered the chart locally with `helm template` using the HelmRelease's values, confirmed the resulting env list has `ENABLE_KUBERNETES: "true"` as the last (winning) entry.
- [ ] After Flux reconciles, confirm Homarr's Tools -> Kubernetes menu is visible and populated.