### PR TITLE
fix(renovate): cap job backoffLimit at 2

### DIFF
--- a/controllers/base/renovate/cronjob.yaml
+++ b/controllers/base/renovate/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:


### PR DESCRIPTION
## What

Set `backoffLimit: 2` on the renovate CronJob's job template (default is 6).

## Why

The 16:00 UTC run on 2026-08-17 failed every attempt with:

```
FATAL: Initialization error
       "errorMessage": "Authentication failure"
```

That is not a retryable condition, but the default `backoffLimit: 6` still burned 7 pods over 11 minutes before the Job gave up. Because the CronJob uses `concurrencyPolicy: Forbid`, a retry storm that long can also suppress the following hourly run.

The auth failure itself was transient and GitHub-side: the token is valid (API returns 200, classic PAT, no expiry set, not rate limited) and every run since 17:00 UTC has succeeded. This PR only changes how loudly a future failure fails.

## Verification

`kubectl kustomize controllers/production/renovate` renders `backoffLimit: 2` under `jobTemplate.spec`; no other output changed.
