### PR TITLE
fix(ci): point pre-push hook at 'mise install'

### DIFF
--- a/scripts/scan-push-secrets.sh
+++ b/scripts/scan-push-secrets.sh
@@ -16,7 +16,7 @@ remote_name="${1:-origin}"
 require_scanner() {
   if ! command -v gitleaks >/dev/null 2>&1; then
     die "gitleaks is not installed, refusing to push.
-  Install it and re-run scripts/install-hooks.sh, or bypass once with
+  Install it with 'mise install', or bypass once with
   'git push --no-verify' if you are certain this push carries no secrets."
   fi
 


### PR DESCRIPTION
## What

Corrects the pre-push hook's failure message to point at `mise install`.

## Why

`247bc66` deleted `scripts/install-hooks.sh` and replaced it with `core.hooksPath = .githooks` plus mise-provisioned tooling, but `scripts/scan-push-secrets.sh` still told you to re-run the deleted script:

```
pre-push: gitleaks is not installed, refusing to push.
  Install it and re-run scripts/install-hooks.sh, or bypass once with
  'git push --no-verify' if you are certain this push carries no secrets.
```

Hit for real on a fresh clone-state machine: the script it names does not exist on any branch, leaving no way forward except `--no-verify`. `.githooks/pre-commit` already had the corrected wording, so this only aligns the push path with it.

## Verification

`shellcheck scripts/scan-push-secrets.sh` clean. Message text only - no change to scan logic.
