### PR TITLE
fix(external-dns): remove obsolete Pi-hole API flag

### DIFF
--- a/controllers/base/external-dns/deployment.yaml
+++ b/controllers/base/external-dns/deployment.yaml
@@ -26,7 +26,6 @@ spec:
         - --registry=txt
         - --policy=upsert-only
         - --provider=pihole
-        - --pihole-api-version=6
         - --pihole-server=https://192.168.50.20
         - --pihole-password=$(EXTERNAL_DNS_PIHOLE_PASSWORD)
         - --pihole-tls-skip-verify


### PR DESCRIPTION
## Summary

- remove the `--pihole-api-version=6` argument removed by ExternalDNS v0.22.0
- retain the explicit `upsert-only` policy, Pi-hole v6 server credentials, TLS behavior, and `.homelab` filters

## Root cause

ExternalDNS v0.22.0 exits during argument parsing with:

```text
flag parsing error: unknown long flag '--pihole-api-version'
```

Pi-hole v5 support was removed in v0.22.0, so the API-version selector was removed as well and v6 is now implicit.

## Validation

- reproduced the live CrashLoopBackOff and fatal argument parser error
- rendered `controllers/production/external-dns`
- Kubernetes server-side dry-run passed
- 70/70 Kustomizations built
- Flux roots rendered: controllers 16, infrastructure 21, apps 117 documents
- Kubeconform: 154 valid, 0 invalid/errors/skipped
- required Pi-hole/policy/domain arguments asserted present
- obsolete flag asserted absent

## Post-merge verification

- reconcile Flux controllers
- require ExternalDNS rollout Ready
- verify v0.22.0 logs successfully synchronize Pi-hole
- verify all current `.homelab` ingress records resolve
