### PR TITLE
fix(cloudflared): suppress token-bearing request logs

### DIFF
--- a/apps/base/utils/cloudflared/deployment.yaml
+++ b/apps/base/utils/cloudflared/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               "tunnel",
               "--no-autoupdate",
               "--loglevel",
-              "info",
+              "fatal",
               "--metrics",
               "0.0.0.0:2000",
               "run",


### PR DESCRIPTION
## Summary

- set cloudflared application logging to `fatal`
- retain metrics and Kubernetes startup/readiness/liveness probes
- retain public endpoint monitoring through Prometheus blackbox probes

## Security reason

Cloudflared `2026.8.2` emitted request-failure logs at `error` level containing complete Jellyfin stream URLs, including user session tokens passed as query parameters. Three exposed Jellyfin sessions were revoked before this change.

`warn` or `error` would continue to permit those request-failure lines. `fatal` suppresses request-level URL logging while independent connector and endpoint monitoring remains active.

## Validation

- exact cloudflared `--help` confirms `fatal` is supported
- production cloudflared overlay rendered
- Kubernetes server-side dry-run passed
- 70/70 Kustomizations built
- Flux roots rendered: controllers 16, infrastructure 21, apps 117 documents
- Kubeconform: 154 valid, 0 invalid/errors/skipped
- Gitleaks: no findings

## Post-merge

- reconcile Flux apps
- require deployment 2/2 Ready
- verify both `/ready` endpoints
- verify public watch/TV/requests/enroll endpoints
- verify failed blackbox probes remain zero
- confirm new connector logs contain no token-bearing URLs
