### PR TITLE
fix(tracearr): allow CPU burst capacity

### DIFF
--- a/apps/base/media/tracearr/deployment.yaml
+++ b/apps/base/media/tracearr/deployment.yaml
@@ -55,5 +55,4 @@ spec:
               cpu: "100m"
             limits:
               memory: "1Gi"
-              cpu: "500m"
       restartPolicy: Always


### PR DESCRIPTION
## Summary

- remove Tracearr's hard `500m` CPU limit
- retain its `100m` CPU request and `512Mi` memory request
- retain the `1Gi` memory limit

## Root cause

Prometheus reported `CPUThrottlingHigh` continuously for Tracearr. The live five-minute ratio showed about 62% of CFS scheduling periods throttled, while actual average usage was only about 0.21 cores and both nodes had substantial CPU headroom. Short Node.js bursts were hitting the hard 0.5-core quota despite no sustained cluster contention.

Removing the CPU limit allows burst capacity while Kubernetes scheduling still accounts for the 100m request and memory remains bounded.

## Validation

- exact resource assertions against the production render
- Kubernetes server-side dry-run passed
- 70/70 Kustomizations built
- Flux roots rendered: controllers 16, infrastructure 21, apps 117 documents
- Kubeconform: 154 valid, 0 invalid/errors/skipped
- Gitleaks: no findings

## Post-merge

- reconcile Flux apps and require Tracearr rollout
- verify the live container has no CPU limit
- verify service/ingress and logs
- wait for the five-minute throttling window and `CPUThrottlingHigh` alert to clear
